### PR TITLE
Fix node platform deriveKeyV2 error

### DIFF
--- a/keeperapi/package-lock.json
+++ b/keeperapi/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@keeper-security/keeperapi",
-  "version": "16.0.56",
+  "version": "16.0.57",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@keeper-security/keeperapi",
-      "version": "16.0.56",
+      "version": "16.0.57",
       "license": "ISC",
       "dependencies": {
         "asmcrypto.js": "^2.3.2",

--- a/keeperapi/package.json
+++ b/keeperapi/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@keeper-security/keeperapi",
   "description": "Keeper API Javascript SDK",
-  "version": "16.0.56",
+  "version": "16.0.57",
   "browser": "dist/index.es.js",
   "main": "dist/index.cjs.js",
   "types": "dist/node/index.d.ts",

--- a/keeperapi/src/node/platform.ts
+++ b/keeperapi/src/node/platform.ts
@@ -301,7 +301,7 @@ export const nodePlatform: Platform = class {
     }
 
     static deriveKeyV2(domain: string, password: KeyWrapper, saltBytes: Uint8Array, iterations: number): Promise<Uint8Array> {
-        const bytes = crypto.pbkdf2Sync(Buffer.of(...Buffer.from(domain), ...nodePlatform.unWrapPassword(password.getKey())), saltBytes, iterations, 64, 'SHA512')
+        const bytes = crypto.pbkdf2Sync(Buffer.of(...Buffer.from(domain), ...nodePlatform.unWrapPassword(password)), saltBytes, iterations, 64, 'SHA512')
         const reducedBytes = crypto.createHmac("SHA256", bytes).update(Buffer.from(domain)).digest()
         return Promise.resolve(reducedBytes);
     }


### PR DESCRIPTION
- remove extra KeyWrapper.getKey() call