### PR TITLE
Support udata for v2 record type

### DIFF
--- a/keeperapi/package-lock.json
+++ b/keeperapi/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@keeper-security/keeperapi",
-  "version": "16.0.59",
+  "version": "16.0.60",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@keeper-security/keeperapi",
-      "version": "16.0.59",
+      "version": "16.0.60",
       "license": "ISC",
       "dependencies": {
         "asmcrypto.js": "^2.3.2",

--- a/keeperapi/package.json
+++ b/keeperapi/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@keeper-security/keeperapi",
   "description": "Keeper API Javascript SDK",
-  "version": "16.0.59",
+  "version": "16.0.60",
   "browser": "dist/index.es.js",
   "main": "dist/index.cjs.js",
   "types": "dist/node/index.d.ts",

--- a/keeperapi/src/vault.ts
+++ b/keeperapi/src/vault.ts
@@ -64,6 +64,10 @@ export type SyncResult = {
     fullSync?: boolean
 }
 
+export type Udata = {
+    file_ids?: string[]
+}
+
 export type DRecord = {
     kind: 'record'
     uid: string
@@ -73,7 +77,7 @@ export type DRecord = {
     shared: boolean
     clientModifiedTime: number
     extra?: any
-    udata?: any
+    udata?: Udata
 }
 
 export type DRecordMetadata = {
@@ -613,7 +617,7 @@ const processRecords = async (records: IRecord[], storage: VaultStorage) => {
         const encryptionType: EncryptionType = rec.version >= 3 ? 'gcm' : 'cbc'
 
         let extra: any
-        let udata: any
+        let udata: Udata | undefined
         try {
             if (rec.extra.byteLength > 0) {
                 const decryptedExtra = await platform.decrypt(rec.extra, recUid, encryptionType, storage)

--- a/keeperapi/src/vault.ts
+++ b/keeperapi/src/vault.ts
@@ -627,7 +627,7 @@ const processRecords = async (records: IRecord[], storage: VaultStorage) => {
                 udata = JSON.parse(rec.udata)
             }
         } catch {
-            console.error('failed to parse the uData')
+            console.error('failed to parse the udata')
         }
         try {
             const decryptedData = await platform.decrypt(rec.data, recUid, encryptionType, storage)


### PR DESCRIPTION
## Description
It was found that in BE when v2 record is edited, its file attachments were wiped out. The root cause was not including the `udata` property when the record is updated.

The fix is to add `udata` property when saving incoming records to the storages.

Jira ticket: https://keeper.atlassian.net/browse/BE-5842