### PR TITLE
Address Node 20 compatibility

### DIFF
--- a/keeperapi/package-lock.json
+++ b/keeperapi/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@keeper-security/keeperapi",
-  "version": "16.0.67",
+  "version": "16.0.68",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@keeper-security/keeperapi",
-      "version": "16.0.67",
+      "version": "16.0.68",
       "license": "ISC",
       "dependencies": {
         "asmcrypto.js": "^2.3.2",

--- a/keeperapi/package.json
+++ b/keeperapi/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@keeper-security/keeperapi",
   "description": "Keeper API Javascript SDK",
-  "version": "16.0.67",
+  "version": "16.0.68",
   "browser": "dist/index.es.js",
   "main": "dist/index.cjs.js",
   "types": "dist/node/index.d.ts",

--- a/keeperapi/src/node/platform.ts
+++ b/keeperapi/src/node/platform.ts
@@ -224,14 +224,11 @@ export const nodePlatform: Platform = class {
     }
 
     static privateDecrypt(data: Uint8Array, key: Uint8Array): Uint8Array {
-        return crypto.privateDecrypt({
-            key: crypto.createPrivateKey({
-                key: Buffer.from(key),
-                type: 'pkcs1',
-                format: 'der',
-            }),
-            padding: RSA_PKCS1_PADDING
-        }, data);
+        const rsaPrivateKey = new NodeRSA(Buffer.from(key), 'pkcs1-private-der', {
+          encryptionScheme: 'pkcs1'
+        })
+        rsaPrivateKey.setOptions({environment: 'browser'}) // use pure implementation, not native (CVE-2023-46809)
+        return rsaPrivateKey.decrypt(Buffer.from(data))
     }
 
     static async privateDecryptEC(data: Uint8Array, privateKey: Uint8Array, publicKey?: Uint8Array, id?: Uint8Array, useHKDF?: boolean): Promise<Uint8Array> {


### PR DESCRIPTION
- use pure RSA implementation (not native) for decryption; Node 20 deprecates it due to CVE-2023-46809