### PR TITLE
BE-5866 - Handle the case of the null security score data in the sync down response

### DIFF
--- a/keeperapi/package-lock.json
+++ b/keeperapi/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@keeper-security/keeperapi",
-  "version": "16.0.71",
+  "version": "16.0.73",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@keeper-security/keeperapi",
-      "version": "16.0.71",
+      "version": "16.0.73",
       "license": "ISC",
       "dependencies": {
         "asmcrypto.js": "^2.3.2",

--- a/keeperapi/package.json
+++ b/keeperapi/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@keeper-security/keeperapi",
   "description": "Keeper API Javascript SDK",
-  "version": "16.0.72",
+  "version": "16.0.73",
   "browser": "dist/index.es.js",
   "main": "dist/index.cjs.js",
   "types": "dist/node/index.d.ts",

--- a/keeperapi/src/vault.ts
+++ b/keeperapi/src/vault.ts
@@ -915,12 +915,13 @@ const processSecurityScoreData = async (securityScoreDataList: Vault.ISecuritySc
           || typeof securityScoreData.revision !== 'number'
         ) continue
 
-        if (!securityScoreData.data) {
-            await storage.delete('security_score_data', securityScoreData.recordUid)
+        const recUid = webSafe64FromBytes(securityScoreData.recordUid)
+
+        if (!securityScoreData.data || securityScoreData.data.length === 0) {
+            await storage.delete('security_score_data', recUid)
             continue
         }
 
-        const recUid = webSafe64FromBytes(securityScoreData.recordUid)
         try {
             const decrypted = await platform.decrypt(securityScoreData.data, recUid, 'gcm', storage)
             const securityScoreDataObj = JSON.parse(platform.bytesToString(decrypted))

--- a/keeperapi/src/vault.ts
+++ b/keeperapi/src/vault.ts
@@ -912,9 +912,13 @@ const processSecurityScoreData = async (securityScoreDataList: Vault.ISecuritySc
     for (const securityScoreData of securityScoreDataList) {
         if (
           !securityScoreData.recordUid
-          || !securityScoreData.data
           || typeof securityScoreData.revision !== 'number'
         ) continue
+
+        if (!securityScoreData.data) {
+            await storage.delete('security_score_data', securityScoreData.recordUid)
+            continue
+        }
 
         const recUid = webSafe64FromBytes(securityScoreData.recordUid)
         try {


### PR DESCRIPTION
# Changes
- Handle the case when the security score data's data field is empty (or empty `Uint8Array`)
- v16.0.73

If a password is removed from a record, the data field is set to `null` in the database table. Then, the following sync-down response will contain the security score data change in the response, and its `data` field is an empty `Uint8Array` value. In such case, the clients should remove the data in the local storage accordingly.