### PR TITLE
BE-6439 Added a new field isSecurityDataFieldEmptyInFullSync in the SyncResult type

### DIFF
--- a/keeperapi/package-lock.json
+++ b/keeperapi/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@keeper-security/keeperapi",
-  "version": "16.0.75",
+  "version": "16.0.76",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@keeper-security/keeperapi",
-      "version": "16.0.75",
+      "version": "16.0.76",
       "license": "ISC",
       "dependencies": {
         "asmcrypto.js": "^2.3.2",

--- a/keeperapi/package.json
+++ b/keeperapi/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@keeper-security/keeperapi",
   "description": "Keeper API Javascript SDK",
-  "version": "16.0.75",
+  "version": "16.0.76",
   "browser": "dist/index.es.js",
   "main": "dist/index.cjs.js",
   "types": "dist/node/index.d.ts",

--- a/keeperapi/src/vault.ts
+++ b/keeperapi/src/vault.ts
@@ -62,7 +62,7 @@ export type SyncResult = {
     error?: string
     continuationToken?: string
     fullSync?: boolean
-    hasSecurityResetOccurred?: boolean
+    isSecurityDataFieldEmptyInFullSync?: boolean
 }
 
 export type Udata = {
@@ -1057,7 +1057,7 @@ export const syncDown = async (options: SyncDownOptions): Promise<SyncResult> =>
             if (resp.cacheStatus == CacheStatus.CLEAR) {
                 await storage.clear()
                 result.fullSync = true
-                result.hasSecurityResetOccurred = resp.breachWatchSecurityData.length === 0
+                result.isSecurityDataFieldEmptyInFullSync = resp.breachWatchSecurityData.length === 0
             }
             if (result.pageCount === 0 && useWorkers && platform.supportsConcurrency && resp.hasMore) {
                 try {

--- a/keeperapi/src/vault.ts
+++ b/keeperapi/src/vault.ts
@@ -62,6 +62,7 @@ export type SyncResult = {
     error?: string
     continuationToken?: string
     fullSync?: boolean
+    hasSecurityResetOccurred?: boolean
 }
 
 export type Udata = {
@@ -1056,6 +1057,7 @@ export const syncDown = async (options: SyncDownOptions): Promise<SyncResult> =>
             if (resp.cacheStatus == CacheStatus.CLEAR) {
                 await storage.clear()
                 result.fullSync = true
+                result.hasSecurityResetOccurred = resp.breachWatchSecurityData.length === 0
             }
             if (result.pageCount === 0 && useWorkers && platform.supportsConcurrency && resp.hasMore) {
                 try {


### PR DESCRIPTION
## Description
When security data is reset by admin, the next sync-down request made by clients will be always full sync-down request. And since the security data is empty, the clients can implicitly interpret that a security data reset might have happened. The clients still need to makes sure if existing records have either password or passkey to make sure its security data is removed by the reset.