### PR TITLE
BE-6439 Pass the isSecurityDataFieldEmptyInFullSync to the continuation token's data

### DIFF
--- a/keeperapi/package-lock.json
+++ b/keeperapi/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@keeper-security/keeperapi",
-  "version": "16.0.76",
+  "version": "16.0.75",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@keeper-security/keeperapi",
-      "version": "16.0.76",
+      "version": "16.0.75",
       "license": "ISC",
       "dependencies": {
         "asmcrypto.js": "^2.3.2",

--- a/keeperapi/package-lock.json
+++ b/keeperapi/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@keeper-security/keeperapi",
-  "version": "16.0.75",
+  "version": "16.0.77",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@keeper-security/keeperapi",
-      "version": "16.0.75",
+      "version": "16.0.77",
       "license": "ISC",
       "dependencies": {
         "asmcrypto.js": "^2.3.2",

--- a/keeperapi/package.json
+++ b/keeperapi/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@keeper-security/keeperapi",
   "description": "Keeper API Javascript SDK",
-  "version": "16.0.76",
+  "version": "16.0.75",
   "browser": "dist/index.es.js",
   "main": "dist/index.cjs.js",
   "types": "dist/node/index.d.ts",

--- a/keeperapi/package.json
+++ b/keeperapi/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@keeper-security/keeperapi",
   "description": "Keeper API Javascript SDK",
-  "version": "16.0.75",
+  "version": "16.0.77",
   "browser": "dist/index.es.js",
   "main": "dist/index.cjs.js",
   "types": "dist/node/index.d.ts",

--- a/keeperapi/src/vault.ts
+++ b/keeperapi/src/vault.ts
@@ -183,7 +183,8 @@ export type DBWRecord = {
     kind: 'bw_record'
     uid: string
     data: any
-    scannedBy: string
+    scannedBy?: string
+    scannedByAccountUid?: string
     type: string
     revision: number
 }
@@ -883,7 +884,8 @@ const processBreachWatchRecords = async (bwRecords: IBreachWatchRecord[], storag
               kind: 'bw_record',
               uid: recUid,
               data: obj,
-              scannedBy: bwRecord.scannedBy,
+              scannedBy: bwRecord.scannedBy ? bwRecord.scannedBy : undefined,
+              scannedByAccountUid: bwRecord.scannedByAccountUid ? webSafe64FromBytes(bwRecord.scannedByAccountUid) : undefined,
               type: 'RECORD',
               revision: bwRecord.revision as number
             })

--- a/keeperapi/src/vault.ts
+++ b/keeperapi/src/vault.ts
@@ -210,6 +210,7 @@ export type DUser = {
 export type DContinuationToken = {
     kind?: 'continuationToken'
     token: string
+    isSecurityDataFieldEmptyInFullSync?: boolean
 }
 
 export type Dependency = {
@@ -1168,7 +1169,8 @@ export const syncDown = async (options: SyncDownOptions): Promise<SyncResult> =>
             result.continuationToken = respContinuationToken
             await storage.put({
                 kind: 'continuationToken',
-                token: respContinuationToken
+                token: respContinuationToken,
+                isSecurityDataFieldEmptyInFullSync: resp.cacheStatus === CacheStatus.CLEAR && resp.breachWatchSecurityData.length === 0,
             })
             if (!resp.hasMore || (options.maxCalls && result.pageCount >= options.maxCalls)) {
                 break

--- a/keeperapi/src/vault.ts
+++ b/keeperapi/src/vault.ts
@@ -62,7 +62,6 @@ export type SyncResult = {
     error?: string
     continuationToken?: string
     fullSync?: boolean
-    isSecurityDataFieldEmptyInFullSync?: boolean
 }
 
 export type Udata = {
@@ -1057,7 +1056,6 @@ export const syncDown = async (options: SyncDownOptions): Promise<SyncResult> =>
             if (resp.cacheStatus == CacheStatus.CLEAR) {
                 await storage.clear()
                 result.fullSync = true
-                result.isSecurityDataFieldEmptyInFullSync = resp.breachWatchSecurityData.length === 0
             }
             if (result.pageCount === 0 && useWorkers && platform.supportsConcurrency && resp.hasMore) {
                 try {


### PR DESCRIPTION
## Changes
1. Pass the isSecurityDataFieldEmptyInFullSync to the continuation token's data
2. A field `scannedByAccountUid` added to the breach watch record data type