### PR TITLE
BE-6600 Return LINKING_BLOCKED_BY_CROSS_REGION login result when API response is REGION_REDIRECT in account switch flow

### DIFF
--- a/keeperapi/package-lock.json
+++ b/keeperapi/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@keeper-security/keeperapi",
-  "version": "16.0.85",
+  "version": "16.0.86",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@keeper-security/keeperapi",
-      "version": "16.0.85",
+      "version": "16.0.86",
       "license": "ISC",
       "dependencies": {
         "asmcrypto.js": "^2.3.2",

--- a/keeperapi/package.json
+++ b/keeperapi/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@keeper-security/keeperapi",
   "description": "Keeper API Javascript SDK",
-  "version": "16.0.85",
+  "version": "16.0.86",
   "browser": "dist/index.es.js",
   "main": "dist/index.cjs.js",
   "types": "dist/node/index.d.ts",

--- a/keeperapi/src/auth.ts
+++ b/keeperapi/src/auth.ts
@@ -113,6 +113,11 @@ export type EncryptionKeys = {
     eccPrivateKey: Uint8Array;
 }
 
+export const enum LoginV3ResultEnum {
+    NOT_LOGGED_IN = 'notLoggedin',
+    LINKING_BLOCKED_BY_CROSS_REGION = 'linkingBlockedByCrossRegion',
+}
+
 export class Auth {
     ssoLogoutUrl: string = ''
     userType: UserType = UserType.normal
@@ -279,7 +284,7 @@ export class Auth {
             ecOnly = false,
             fromSessionToken = undefined
         }: Partial<LoginPayload>
-    ) {
+    ): Promise<{result: LoginV3ResultEnum} | undefined> {
         this._username = username || this.options.sessionStorage?.lastUsername || ''
 
         let wrappedPassword: KeyWrapper | undefined;
@@ -357,7 +362,7 @@ export class Auth {
             }
             if (resumeSessionOnly && loginResponse && (loginResponse.loginState != Authentication.LoginState.LOGGED_IN)) {
                 return {
-                    result: 'notLoggedin'
+                    result: LoginV3ResultEnum.NOT_LOGGED_IN,
                 }
             }
             console.log(loginResponse)
@@ -395,7 +400,7 @@ export class Auth {
                     break;
                 case Authentication.LoginState.DEVICE_APPROVAL_REQUIRED:
                 case Authentication.LoginState.REQUIRES_DEVICE_ENCRYPTED_DATA_KEY:
-                    if (givenSessionToken) return { result: 'notLoggedin' }
+                    if (givenSessionToken) return { result: LoginV3ResultEnum.NOT_LOGGED_IN }
                     try {
                         loginToken = await this.verifyDevice(username, loginResponse.encryptedLoginToken, loginResponse.loginState == Authentication.LoginState.REQUIRES_DEVICE_ENCRYPTED_DATA_KEY)
                     } catch (e: any) {
@@ -407,6 +412,12 @@ export class Auth {
                     handleError('license_expired', loginResponse, new Error(loginResponse.message))
                     return;
                 case Authentication.LoginState.REGION_REDIRECT:
+                    if (!!fromSessionToken) {
+                        return {
+                            result: LoginV3ResultEnum.LINKING_BLOCKED_BY_CROSS_REGION,
+                        }
+                    }
+
                     // TODO: put region_redirect in its own loop since
                     // its unique to the other states.
                     this.options.host = loginResponse.stateSpecificValue

--- a/keeperapi/src/auth.ts
+++ b/keeperapi/src/auth.ts
@@ -80,7 +80,7 @@ export type LoginPayload = {
     resumeSessionOnly?: boolean
     givenSessionToken?: string
     ecOnly?: boolean
-    fromSessionToken?: Uint8Array | null
+    primaryAccountSessionTokenForLinking?: Uint8Array | null
 }
 
 export enum UserType {
@@ -282,7 +282,7 @@ export class Auth {
             resumeSessionOnly = false,
             givenSessionToken = undefined,
             ecOnly = false,
-            fromSessionToken = undefined
+            primaryAccountSessionTokenForLinking = undefined
         }: Partial<LoginPayload>
     ): Promise<{result: LoginV3ResultEnum} | undefined> {
         this._username = username || this.options.sessionStorage?.lastUsername || ''
@@ -329,7 +329,7 @@ export class Auth {
                 loginMethod: loginMethod,
                 cloneCode: await this.options.sessionStorage?.getCloneCode(this.options.host as KeeperEnvironment, this._username),
                 v2TwoFactorToken: v2TwoFactorToken,
-                fromSessionToken,
+                fromSessionToken: primaryAccountSessionTokenForLinking,
             })
             if (loginType !== LoginType.NORMAL && !!loginType) {
                 startLoginRequest.loginType = loginType
@@ -412,7 +412,7 @@ export class Auth {
                     handleError('license_expired', loginResponse, new Error(loginResponse.message))
                     return;
                 case Authentication.LoginState.REGION_REDIRECT:
-                    if (!!fromSessionToken) {
+                    if (!!primaryAccountSessionTokenForLinking) {
                         return {
                             result: LoginV3ResultEnum.LINKING_BLOCKED_BY_CROSS_REGION,
                         }


### PR DESCRIPTION
## Changes
1. Return LINKING_BLOCKED_BY_CROSS_REGION login result when API response is REGION_REDIRECT in account switch flow
2. v16.0.86
3. Renamed the loginV3's param `fromSessionToken` to `primaryAccountSessionTokenForLinking for clarity`