### PR TITLE
BE-6600 The loginV3 function blocks account linking for YubiKey 2FA accounts if disableLinkingForAccountWithYubikey2fa is set

### DIFF
--- a/keeperapi/package-lock.json
+++ b/keeperapi/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@keeper-security/keeperapi",
-  "version": "16.0.86",
+  "version": "16.0.87",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@keeper-security/keeperapi",
-      "version": "16.0.86",
+      "version": "16.0.87",
       "license": "ISC",
       "dependencies": {
         "asmcrypto.js": "^2.3.2",

--- a/keeperapi/package.json
+++ b/keeperapi/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@keeper-security/keeperapi",
   "description": "Keeper API Javascript SDK",
-  "version": "16.0.86",
+  "version": "16.0.87",
   "browser": "dist/index.es.js",
   "main": "dist/index.cjs.js",
   "types": "dist/node/index.d.ts",

--- a/keeperapi/src/auth.ts
+++ b/keeperapi/src/auth.ts
@@ -81,6 +81,7 @@ export type LoginPayload = {
     givenSessionToken?: string
     ecOnly?: boolean
     primaryAccountSessionTokenForLinking?: Uint8Array | null
+    disableLinkingForAccountWithYubikey2fa?: boolean
 }
 
 export enum UserType {
@@ -116,6 +117,7 @@ export type EncryptionKeys = {
 export const enum LoginV3ResultEnum {
     NOT_LOGGED_IN = 'notLoggedin',
     LINKING_BLOCKED_BY_CROSS_REGION = 'linkingBlockedByCrossRegion',
+    LINKING_BLOCKED_BY_YUBIKEY_2FA = 'linkingBlockedByYubikey2fa',
 }
 
 export class Auth {
@@ -282,7 +284,8 @@ export class Auth {
             resumeSessionOnly = false,
             givenSessionToken = undefined,
             ecOnly = false,
-            primaryAccountSessionTokenForLinking = undefined
+            primaryAccountSessionTokenForLinking = undefined,
+            disableLinkingForAccountWithYubikey2fa,
         }: Partial<LoginPayload>
     ): Promise<{result: LoginV3ResultEnum} | undefined> {
         this._username = username || this.options.sessionStorage?.lastUsername || ''
@@ -468,6 +471,11 @@ export class Auth {
                     break;
                 case Authentication.LoginState.REQUIRES_2FA:
                     try{
+                        if (!!disableLinkingForAccountWithYubikey2fa && !!primaryAccountSessionTokenForLinking) {
+                            return {
+                                result: LoginV3ResultEnum.LINKING_BLOCKED_BY_YUBIKEY_2FA,
+                            }
+                        }
                         loginToken = await this.handleTwoFactor(loginResponse)
                     } catch(e: any){
                         if (e?.message && e.message == 'push_declined'){

--- a/keeperapi/src/auth.ts
+++ b/keeperapi/src/auth.ts
@@ -271,7 +271,13 @@ export class Auth {
     }
 
     /**
-     * useAlternate is to pass to the next function to use an alternate method, for testing a different path.
+     * @param {LoginPayload} payload - Options for login.
+     * @param {boolean} [payload.disableLinkingForAccountWithYubikey2fa] -
+     *        Opt-out flag for linking YubiKey 2FA accounts.
+     *        Normally, these accounts can be linked, but some clients
+     *        have technical issues that prevent them from supporting
+     *        the linking flow. When true, `loginV3` will block the
+     *        linking attempt and return `LINKING_BLOCKED_BY_YUBIKEY_2FA`.
      */
     async loginV3(
         {
@@ -285,6 +291,11 @@ export class Auth {
             givenSessionToken = undefined,
             ecOnly = false,
             primaryAccountSessionTokenForLinking = undefined,
+            /*
+             * Prevents linking YubiKey 2FA accounts.
+             * Normally, these accounts can be linked, but some clients have technical issues
+             * that prevent them from supporting the linking flow, so they can opt out via this flag.
+             */
             disableLinkingForAccountWithYubikey2fa,
         }: Partial<LoginPayload>
     ): Promise<{result: LoginV3ResultEnum} | undefined> {


### PR DESCRIPTION
## Changes
1. The loginV3 function blocks account linking for YubiKey 2FA accounts if `disableLinkingForAccountWithYubikey2fa` is set
2. v16.0.87