### PR TITLE
Login and records implementation

### DIFF
--- a/.github/workflows/publish.keeper-sdk.yml
+++ b/.github/workflows/publish.keeper-sdk.yml
@@ -1,0 +1,32 @@
+name: Publish Keeper SDK to NPM
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish-npm:
+    environment: prod
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: ./KeeperSdk
+
+    steps:
+      - name: Get the source code
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Publish package
+        run: npm publish

--- a/KeeperSdk/package.json
+++ b/KeeperSdk/package.json
@@ -11,12 +11,15 @@
         "format:check": "prettier --check .",
         "test": "jest",
         "types": "tsc --watch",
-        "types:ci": "tsc"
+        "types:ci": "tsc",
+        "prepublishOnly": "npm run build"
     },
     "dependencies": {
         "@keeper-security/keeperapi": "17.1.0",
-        "@types/node": "^20.9.1",
         "ts-node": "^10.7.0",
         "typescript": "^4.6.3"
+    },
+    "devDependencies": {
+        "@types/node": "^25.6.0"
     }
 }

--- a/KeeperSdk/package.json
+++ b/KeeperSdk/package.json
@@ -1,0 +1,22 @@
+{
+    "name": "keeper-sdk",
+    "version": "1.0.0",
+    "description": "High-level wrapper for Keeper Security JavaScript SDK",
+    "main": "src/index.ts",
+    "scripts": {
+        "build": "tsc",
+        "clean": "rm -rf dist",
+        "link-local": "npm link ../keeperapi",
+        "format": "prettier --write .",
+        "format:check": "prettier --check .",
+        "test": "jest",
+        "types": "tsc --watch",
+        "types:ci": "tsc"
+    },
+    "dependencies": {
+        "@keeper-security/keeperapi": "17.1.0",
+        "@types/node": "^20.9.1",
+        "ts-node": "^10.7.0",
+        "typescript": "^4.6.3"
+    }
+}

--- a/KeeperSdk/package.json
+++ b/KeeperSdk/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "keeper-sdk",
+    "name": "@keeper-security/keeper-sdk-javascript",
     "version": "1.0.0",
     "description": "High-level wrapper for Keeper Security JavaScript SDK",
     "main": "src/index.ts",

--- a/KeeperSdk/src/auth/ConsoleAuthUI.ts
+++ b/KeeperSdk/src/auth/ConsoleAuthUI.ts
@@ -1,0 +1,157 @@
+import readline from 'readline/promises'
+import { setTimeout as delay } from 'timers/promises'
+import type { AuthUI3, DeviceApprovalChannel, TwoFactorChannelData } from '@keeper-security/keeperapi'
+import { Authentication } from '@keeper-security/keeperapi'
+import { logger, extractErrorMessage, KeeperSdkError, AuthDefaults, ResultCodes } from '../utils'
+
+export class ConsoleAuthUI implements AuthUI3 {
+    private static readonly DEVICE_VERIFICATION = {
+        Email: 0,
+        KeeperPush: 1,
+        TFA: 2,
+        AdminApproval: 3,
+    } as const
+
+    private static channelName(channel: number): string {
+        switch (channel) {
+            case ConsoleAuthUI.DEVICE_VERIFICATION.Email:
+                return 'Email Verification'
+            case ConsoleAuthUI.DEVICE_VERIFICATION.KeeperPush:
+                return 'Keeper Push'
+            case ConsoleAuthUI.DEVICE_VERIFICATION.TFA:
+                return 'Two-Factor Authentication'
+            case ConsoleAuthUI.DEVICE_VERIFICATION.AdminApproval:
+                return 'Admin Approval'
+            default:
+                return `Channel ${channel}`
+        }
+    }
+
+    private static twoFactorChannelName(channelType: Authentication.TwoFactorChannelType): string {
+        switch (channelType) {
+            case Authentication.TwoFactorChannelType.TWO_FA_CT_TOTP:
+                return 'Authenticator App (TOTP)'
+            case Authentication.TwoFactorChannelType.TWO_FA_CT_SMS:
+                return 'SMS'
+            case Authentication.TwoFactorChannelType.TWO_FA_CT_DUO:
+                return 'Duo Security'
+            case Authentication.TwoFactorChannelType.TWO_FA_CT_RSA:
+                return 'RSA SecurID'
+            case Authentication.TwoFactorChannelType.TWO_FA_CT_DNA:
+                return 'Keeper DNA'
+            case Authentication.TwoFactorChannelType.TWO_FA_CT_U2F:
+                return 'U2F Security Key'
+            case Authentication.TwoFactorChannelType.TWO_FA_CT_WEBAUTHN:
+                return 'WebAuthn Security Key'
+            case Authentication.TwoFactorChannelType.TWO_FA_CT_KEEPER:
+                return 'Keeper'
+            default:
+                throw new KeeperSdkError(`Unsupported 2FA channel type: ${channelType}`, ResultCodes.UNSUPPORTED_2FA_CHANNEL)
+        }
+    }
+
+    private static async waitWithCancel(timeoutMs: number, cancel?: Promise<void>): Promise<void> {
+        if (!cancel) {
+            await delay(timeoutMs)
+            return
+        }
+        await Promise.race([delay(timeoutMs), cancel])
+    }
+
+    public async waitForDeviceApproval(channels: DeviceApprovalChannel[], isCloud: boolean): Promise<boolean> {
+        const rl = readline.createInterface({ input: process.stdin, output: process.stdout })
+
+        try {
+            logger.info('\n--- Device Approval Required ---')
+            logger.info('This device needs to be approved before you can log in.')
+            logger.info('Available verification methods:')
+            channels.forEach((ch, i) => {
+                logger.info(`  ${i + 1}. ${ConsoleAuthUI.channelName(ch.channel)}`)
+            })
+
+            const choice = (await rl.question('\nSelect method (number): ')).trim()
+            const idx = parseInt(choice, 10) - 1
+
+            if (isNaN(idx) || idx < 0 || idx >= channels.length) {
+                logger.warn('Invalid selection, cancelling.')
+                return false
+            }
+
+            const selected = channels[idx]
+            logger.info(`\nSending ${ConsoleAuthUI.channelName(selected.channel)} request...`)
+            await selected.sendApprovalRequest()
+
+            if (selected.validateCode) {
+                const code = (await rl.question('Enter verification code: ')).trim()
+                if (!code) return false
+                await selected.validateCode(code)
+            } else {
+                logger.info('Approval request sent. Waiting for approval on your other device...')
+                await ConsoleAuthUI.waitWithCancel(AuthDefaults.APPROVAL_TIMEOUT_MS)
+            }
+
+            return true
+        } catch (e) {
+            logger.error('Device approval error:', extractErrorMessage(e))
+            return false
+        } finally {
+            rl.close()
+        }
+    }
+
+    public async waitForTwoFactorCode(channels: TwoFactorChannelData[], cancel: Promise<void>): Promise<boolean> {
+        const rl = readline.createInterface({ input: process.stdin, output: process.stdout })
+
+        try {
+            logger.info('\n--- Two-Factor Authentication Required ---')
+            logger.info('Available 2FA methods:')
+            channels.forEach((ch, i) => {
+                const name = ConsoleAuthUI.twoFactorChannelName(ch.channel.channelType!)
+                logger.info(`  ${i + 1}. ${name}`)
+            })
+
+            const choice = (await rl.question('\nSelect method (number): ')).trim()
+            const idx = parseInt(choice, 10) - 1
+
+            if (isNaN(idx) || idx < 0 || idx >= channels.length) {
+                logger.warn('Invalid selection, cancelling.')
+                return false
+            }
+
+            const selected = channels[idx]
+            const name = ConsoleAuthUI.twoFactorChannelName(selected.channel.channelType!)
+
+            if (selected.availablePushes && selected.availablePushes.length > 0) {
+                const pushChoice = (await rl.question(`Send push notification for ${name}? (y/n): `)).trim()
+                if (pushChoice.toLowerCase() === 'y' && selected.sendPush) {
+                    selected.sendPush(selected.availablePushes[0])
+                    logger.info('Push sent. Waiting for approval...')
+                    await ConsoleAuthUI.waitWithCancel(AuthDefaults.APPROVAL_TIMEOUT_MS, cancel)
+                    return true
+                }
+            }
+
+            const code = (await rl.question(`Enter ${name} code: `)).trim()
+            if (!code) return false
+
+            selected.sendCode(code)
+            await ConsoleAuthUI.waitWithCancel(AuthDefaults.CODE_VALIDATION_DELAY_MS, cancel)
+            return true
+        } catch (e) {
+            logger.error('2FA error:', extractErrorMessage(e))
+            return false
+        } finally {
+            rl.close()
+        }
+    }
+
+    public async getPassword(isAlternate: boolean): Promise<string> {
+        const rl = readline.createInterface({ input: process.stdin, output: process.stdout })
+        try {
+            const label = isAlternate ? 'alternate master password' : 'master password'
+            return (await rl.question(`Enter your ${label}: `)).trim()
+        } finally {
+            rl.close()
+        }
+    }
+}

--- a/KeeperSdk/src/auth/ConsoleLogin.ts
+++ b/KeeperSdk/src/auth/ConsoleLogin.ts
@@ -1,0 +1,301 @@
+import readline from 'readline/promises'
+import { KeeperVault } from '../vault/KeeperVault'
+import {
+    logger,
+    extractResultCode,
+    extractErrorMessage,
+    KeeperSdkError,
+    SdkDefaults,
+    AuthDefaults,
+    ResultCodes,
+    KEEPER_PUBLIC_HOSTS,
+} from '../utils'
+import { FileConfigLoader } from './SessionManager'
+import type { KeeperJsonConfig } from './SessionManager'
+
+const defaultConfigLoader = new FileConfigLoader()
+
+let rlManager: ReadlineManager | null = null
+let suppressionDepth = 0
+let originals: {
+    log: typeof console.log
+    warn: typeof console.warn
+    debug: typeof console.debug
+    error: typeof console.error
+    stdoutWrite: typeof process.stdout.write
+    stderrWrite: typeof process.stderr.write
+} | null = null
+
+enum CliCharAction {
+    Submit,
+    Cancel,
+    Backspace,
+    Append,
+}
+
+function classifyInputChar(ch: string): CliCharAction {
+    if (ch === '\n' || ch === '\r') return CliCharAction.Submit
+    if (ch === '\u0003') return CliCharAction.Cancel
+    if (ch === '\u007F' || ch === '\b') return CliCharAction.Backspace
+    return CliCharAction.Append
+}
+
+class ReadlineManager {
+    private rl: readline.Interface | null = null
+
+    private getOrCreate(): readline.Interface {
+        if (!this.rl) {
+            this.rl = readline.createInterface({
+                input: process.stdin,
+                output: process.stdout,
+            })
+        }
+        return this.rl
+    }
+
+    public async question(query: string): Promise<string> {
+        const rl = this.getOrCreate()
+        const answer = await rl.question(query)
+        return answer.trim()
+    }
+
+    public close(): void {
+        if (this.rl) {
+            this.rl.close()
+            this.rl = null
+        }
+    }
+}
+
+function getReadlineManager(): ReadlineManager {
+    if (!rlManager) {
+        rlManager = new ReadlineManager()
+    }
+    return rlManager
+}
+
+export function prompt(question: string, masked = false): Promise<string> {
+    const mgr = getReadlineManager()
+    if (!masked) {
+        return mgr.question(question)
+    }
+
+    return new Promise((resolve, reject) => {
+        mgr.close()
+        process.stdout.write(question)
+        let buf = ''
+        process.stdin.setRawMode(true)
+        process.stdin.resume()
+        process.stdin.setEncoding('utf8')
+
+        function exitRawMode() {
+            process.stdout.write('\n')
+            process.stdin.setRawMode(false)
+            process.stdin.pause()
+            process.stdin.removeListener('data', onData)
+        }
+
+        const onData = (str: string) => {
+            for (const ch of str) {
+                switch (classifyInputChar(ch)) {
+                    case CliCharAction.Submit:
+                        exitRawMode()
+                        resolve(buf.trim())
+                        return
+                    case CliCharAction.Cancel:
+                        exitRawMode()
+                        reject(new KeeperSdkError('Operation cancelled by user.', ResultCodes.USER_CANCELLED))
+                        return
+                    case CliCharAction.Backspace:
+                        if (buf.length > 0) {
+                            buf = buf.slice(0, -1)
+                            process.stdout.write('\b \b')
+                        }
+                        break
+                    case CliCharAction.Append:
+                        buf += ch
+                        process.stdout.write('*')
+                        break
+                }
+            }
+        }
+
+        process.stdin.on('data', onData)
+    })
+}
+
+export async function loadKeeperConfig(preloaded?: KeeperJsonConfig): Promise<KeeperJsonConfig> {
+    if (preloaded) return preloaded
+    return defaultConfigLoader.load()
+}
+
+export async function resolveServer(username?: string, preloadedConfig?: KeeperJsonConfig): Promise<string> {
+    const config = await loadKeeperConfig(preloadedConfig)
+    const configServer = config.last_server || config.server
+
+    if (username) {
+        const users = config.users || []
+        const userEntry = users.find(
+            (u) => u.user?.toLowerCase() === username.toLowerCase()
+        )
+        if (userEntry?.server) return userEntry.server
+    }
+
+    if (configServer) return configServer
+
+    logger.info('Select server region:')
+    const entries = Object.entries(KEEPER_PUBLIC_HOSTS)
+    entries.forEach(([region, host], i) => {
+        logger.info(`  ${i + 1}. ${region} (${host})`)
+    })
+    logger.info(`  Or enter a hostname directly (e.g. dev.keepersecurity.com)`)
+
+    const choice = await prompt('Region [1 = US]: ')
+
+    if (!choice) return KEEPER_PUBLIC_HOSTS.US
+
+    const idx = parseInt(choice, 10) - 1
+    if (idx >= 0 && idx < entries.length) return entries[idx][1]
+
+    const byName = KEEPER_PUBLIC_HOSTS[choice.toUpperCase()]
+    if (byName) return byName
+
+    return choice
+}
+
+export function suppressLogs(): () => void {
+    if (suppressionDepth === 0) {
+        originals = {
+            log: console.log,
+            warn: console.warn,
+            debug: console.debug,
+            error: console.error,
+            stdoutWrite: process.stdout.write.bind(process.stdout),
+            stderrWrite: process.stderr.write.bind(process.stderr),
+        }
+        console.log = () => {}
+        console.warn = () => {}
+        console.debug = () => {}
+        console.error = () => {}
+        process.stdout.write = (() => true) as typeof process.stdout.write
+        process.stderr.write = (() => true) as typeof process.stderr.write
+    }
+    suppressionDepth++
+
+    let restored = false
+    return () => {
+        if (restored) return
+        restored = true
+        suppressionDepth--
+        if (suppressionDepth === 0 && originals) {
+            console.log = originals.log
+            console.warn = originals.warn
+            console.debug = originals.debug
+            console.error = originals.error
+            process.stdout.write = originals.stdoutWrite
+            process.stderr.write = originals.stderrWrite
+            originals = null
+        }
+    }
+}
+
+async function withSuppressedOutput<T>(fn: () => Promise<T>): Promise<T> {
+    const restore = suppressLogs()
+    try {
+        return await fn()
+    } finally {
+        restore()
+    }
+}
+
+export async function login(): Promise<KeeperVault> {
+    const config = await loadKeeperConfig()
+    const defaultUsername = config.last_login || config.user || ''
+
+    const host = defaultUsername
+        ? await resolveServer(defaultUsername, config)
+        : undefined
+
+    if (defaultUsername && host) {
+        const vault = await tryPersistentLogin(host, defaultUsername)
+        if (vault) return vault
+    }
+
+    let username: string
+    if (defaultUsername) {
+        logger.info(`Enter master password for ${defaultUsername}`)
+        username = defaultUsername
+    } else {
+        username = await prompt('Username (email): ')
+    }
+
+    if (!username) {
+        throw new KeeperSdkError('Username is required.', ResultCodes.MISSING_USERNAME)
+    }
+
+    const resolvedHost = host || await resolveServer(username, config)
+    return await interactiveLogin(resolvedHost, username)
+}
+
+async function tryPersistentLogin(host: string, username: string): Promise<KeeperVault | null> {
+    const vault = new KeeperVault({ host, clientVersion: SdkDefaults.CLIENT_VERSION })
+    try {
+        await withSuppressedOutput(() => vault.resumeSession())
+        logger.info(`Logging in to Keeper as ${username}`)
+        logger.info('Successfully authenticated with Persistent Login')
+        return await syncVault(vault)
+    } catch (err) {
+        logger.debug('Persistent login failed:', extractErrorMessage(err))
+        vault.disconnect()
+        return null
+    }
+}
+
+async function interactiveLogin(host: string, username: string): Promise<KeeperVault> {
+    const vault = new KeeperVault({ host, clientVersion: SdkDefaults.CLIENT_VERSION })
+
+    for (let attempt = 1; attempt <= AuthDefaults.MAX_LOGIN_ATTEMPTS; attempt++) {
+        const password = await prompt('Password: ', true)
+
+        if (!password) {
+            throw new KeeperSdkError('Password is required.', ResultCodes.MISSING_PASSWORD)
+        }
+
+        try {
+            await withSuppressedOutput(() => vault.login(username, password))
+            logger.info('Successfully authenticated with Master Password\n')
+            return await syncVault(vault)
+        } catch (err) {
+            const resultCode = extractResultCode(err)
+            if (resultCode === ResultCodes.INVALID_CREDENTIALS) {
+                const remaining = AuthDefaults.MAX_LOGIN_ATTEMPTS - attempt
+                if (remaining > 0) {
+                    logger.warn(`Invalid credentials (${remaining} attempt${remaining === 1 ? '' : 's'} remaining)`)
+                    continue
+                }
+                throw new KeeperSdkError(
+                    `Maximum login attempts (${AuthDefaults.MAX_LOGIN_ATTEMPTS}) exceeded.`,
+                    ResultCodes.MAX_ATTEMPTS_EXCEEDED
+                )
+            }
+            throw KeeperSdkError.from(err)
+        }
+    }
+
+    throw new KeeperSdkError(
+        `Maximum login attempts (${AuthDefaults.MAX_LOGIN_ATTEMPTS}) exceeded.`,
+        ResultCodes.MAX_ATTEMPTS_EXCEEDED
+    )
+}
+
+async function syncVault(vault: KeeperVault): Promise<KeeperVault> {
+    logger.info('Syncing vault...')
+    await withSuppressedOutput(() => vault.sync())
+    logger.info(`Vault synced. ${vault.getSummary().recordCount} records loaded.\n`)
+    return vault
+}
+
+export function cleanup(vault: KeeperVault): void {
+    vault.disconnect()
+    getReadlineManager().close()
+}

--- a/KeeperSdk/src/auth/SessionManager.ts
+++ b/KeeperSdk/src/auth/SessionManager.ts
@@ -1,7 +1,7 @@
 import fs from 'fs/promises'
 import path from 'path'
 import os from 'os'
-import type { DeviceConfig, SessionStorage, KeeperHost, SessionParams } from '@keeper-security/keeperapi'
+import { normal64Bytes, type DeviceConfig, type SessionStorage, type KeeperHost, type SessionParams } from '@keeper-security/keeperapi'
 import { logger, extractErrorMessage, SdkDefaults } from '../utils'
 
 export type ConfigurationUser = {
@@ -34,8 +34,8 @@ export type KeeperJsonConfig = {
 }
 
 type ResolvedDevice = {
-    deviceToken: Buffer
-    privateKey: Buffer
+    deviceToken: Uint8Array
+    privateKey: Uint8Array
     serverInfo: Array<Required<ConfigurationServerConfig>>
 }
 
@@ -141,7 +141,7 @@ export class SessionManager implements SessionStorage {
         if (device) {
             const serverInfo = device.serverInfo.find(si => si.server === hostStr)
             if (serverInfo) {
-                return SessionManager.base64urlDecode(serverInfo.clone_code)
+                return normal64Bytes(serverInfo.clone_code)
             }
         }
 
@@ -229,19 +229,8 @@ export class SessionManager implements SessionStorage {
     private async lookupDeviceInKeeperConfig(normalizedUsername: string): Promise<ResolvedDevice | null> {
         const kc = await this.loadKeeperConfig()
 
-        if (kc.device_token && kc.private_key && kc.user?.toLowerCase() === normalizedUsername) {
-            const serverInfo: Array<Required<ConfigurationServerConfig>> = []
-            const server = kc.last_server || kc.server
-            if (server && kc.clone_code) {
-                serverInfo.push({ server, clone_code: kc.clone_code })
-            }
-            return {
-                deviceToken: SessionManager.base64urlDecode(kc.device_token),
-                privateKey: SessionManager.base64urlDecode(kc.private_key),
-                serverInfo,
-            }
-        }
-
+        // Prefer explicit user->last_device mapping first when present.
+        // In mixed configs the top-level device fields can point to an older device.
         if (kc.users && kc.devices) {
             const user = kc.users.find(u => u.user?.toLowerCase() === normalizedUsername)
             if (user?.last_device?.device_token) {
@@ -249,14 +238,27 @@ export class SessionManager implements SessionStorage {
                 const device = kc.devices.find(d => d.device_token === deviceTokenStr)
                 if (device?.private_key) {
                     return {
-                        deviceToken: SessionManager.base64urlDecode(deviceTokenStr),
-                        privateKey: SessionManager.base64urlDecode(device.private_key),
+                        deviceToken: normal64Bytes(deviceTokenStr),
+                        privateKey: normal64Bytes(device.private_key),
                         serverInfo: (device.server_info || [])
                             .filter((si): si is Required<ConfigurationServerConfig> =>
                                 !!si.server && !!si.clone_code
                             ),
                     }
                 }
+            }
+        }
+
+        if (kc.device_token && kc.private_key && kc.user?.toLowerCase() === normalizedUsername) {
+            const serverInfo: Array<Required<ConfigurationServerConfig>> = []
+            const server = kc.last_server || kc.server
+            if (server && kc.clone_code) {
+                serverInfo.push({ server, clone_code: kc.clone_code })
+            }
+            return {
+                deviceToken: normal64Bytes(kc.device_token),
+                privateKey: normal64Bytes(kc.private_key),
+                serverInfo,
             }
         }
 
@@ -271,7 +273,4 @@ export class SessionManager implements SessionStorage {
         return true
     }
 
-    private static base64urlDecode(str: string): Buffer {
-        return Buffer.from(str.replace(/-/g, '+').replace(/_/g, '/'), 'base64')
-    }
 }

--- a/KeeperSdk/src/auth/SessionManager.ts
+++ b/KeeperSdk/src/auth/SessionManager.ts
@@ -1,0 +1,277 @@
+import fs from 'fs/promises'
+import path from 'path'
+import os from 'os'
+import type { DeviceConfig, SessionStorage, KeeperHost, SessionParams } from '@keeper-security/keeperapi'
+import { logger, extractErrorMessage, SdkDefaults } from '../utils'
+
+export type ConfigurationUser = {
+    user?: string
+    server?: string
+    last_device?: { device_token?: string }
+}
+
+export type ConfigurationServerConfig = {
+    server?: string
+    clone_code?: string
+}
+
+export type ConfigurationDeviceConfig = {
+    device_token?: string
+    private_key?: string
+    server_info?: Array<ConfigurationServerConfig>
+}
+
+export type KeeperJsonConfig = {
+    last_login?: string
+    last_server?: string
+    user?: string
+    server?: string
+    device_token?: string
+    private_key?: string
+    clone_code?: string
+    users?: Array<ConfigurationUser>
+    devices?: Array<ConfigurationDeviceConfig>
+}
+
+type ResolvedDevice = {
+    deviceToken: Buffer
+    privateKey: Buffer
+    serverInfo: Array<Required<ConfigurationServerConfig>>
+}
+
+export interface ConfigLoader {
+    load(): Promise<KeeperJsonConfig>
+    save(config: KeeperJsonConfig): Promise<void>
+    readonly configDir: string
+}
+
+export class FileConfigLoader implements ConfigLoader {
+    public readonly configDir: string
+
+    constructor(configDir?: string) {
+        this.configDir = configDir || path.join(os.homedir(), SdkDefaults.CONFIG_DIR)
+    }
+
+    async load(): Promise<KeeperJsonConfig> {
+        const configPath = path.join(this.configDir, 'config.json')
+        try {
+            const content = await fs.readFile(configPath, 'utf-8')
+            const parsed: unknown = JSON.parse(content)
+            if (SessionManager.isValidKeeperConfig(parsed)) {
+                return parsed
+            }
+        } catch (err) {
+            logger.debug('Failed to load keeper config:', extractErrorMessage(err))
+        }
+        return {}
+    }
+
+    async save(config: KeeperJsonConfig): Promise<void> {
+        const configPath = path.join(this.configDir, 'config.json')
+        await fs.writeFile(configPath, JSON.stringify(config, null, 2), { mode: 0o600 })
+    }
+}
+
+export class SessionManager implements SessionStorage {
+    private readonly configLoader: ConfigLoader
+    private sessionParams: SessionParams | null = null
+    private _lastUsername?: string
+    private _keeperConfig: KeeperJsonConfig | null = null
+    private _deviceCache: { username: string; device: ResolvedDevice | null } | null = null
+    private sessionDevices = new Map<string, DeviceConfig>()
+    private sessionCloneCodes = new Map<string, Uint8Array>()
+
+    constructor(configDir?: string)
+    constructor(loader: ConfigLoader)
+    constructor(configDirOrLoader?: string | ConfigLoader) {
+        if (typeof configDirOrLoader === 'string' || configDirOrLoader === undefined) {
+            this.configLoader = new FileConfigLoader(configDirOrLoader as string | undefined)
+        } else {
+            this.configLoader = configDirOrLoader
+        }
+    }
+
+    public get configDir(): string {
+        return this.configLoader.configDir
+    }
+
+    public get lastUsername(): string | undefined {
+        return this._lastUsername
+    }
+
+    public async getLastUsername(): Promise<string | undefined> {
+        if (this._lastUsername) return this._lastUsername
+        const kc = await this.loadKeeperConfig()
+        return kc.last_login || kc.user || undefined
+    }
+
+    public async getDeviceConfig(host: string): Promise<DeviceConfig> {
+        const username = await this.getLastUsername()
+        if (username) {
+            const device = await this.findDeviceInKeeperConfig(username)
+            if (device) {
+                return {
+                    deviceToken: device.deviceToken,
+                    privateKey: device.privateKey,
+                }
+            }
+        }
+
+        return this.sessionDevices.get(host) || {}
+    }
+
+    public createOnDeviceConfig(host: string): (deviceConfig: DeviceConfig) => Promise<void> {
+        return async (deviceConfig: DeviceConfig) => {
+            this.sessionDevices.set(host, { ...deviceConfig })
+        }
+    }
+
+    private cloneCodeKey(host: KeeperHost, username: string): string {
+        return `${host}::${username}`
+    }
+
+    public async getCloneCode(host: KeeperHost, username: string): Promise<Uint8Array | null> {
+        const hostStr = String(host)
+
+        const key = this.cloneCodeKey(host, username)
+        const sessionCode = this.sessionCloneCodes.get(key)
+        if (sessionCode) return sessionCode
+
+        const device = await this.findDeviceInKeeperConfig(username)
+        if (device) {
+            const serverInfo = device.serverInfo.find(si => si.server === hostStr)
+            if (serverInfo) {
+                return SessionManager.base64urlDecode(serverInfo.clone_code)
+            }
+        }
+
+        return null
+    }
+
+    public async saveCloneCode(host: KeeperHost, username: string, cloneCode: Uint8Array): Promise<void> {
+        const key = this.cloneCodeKey(host, username)
+        this.sessionCloneCodes.set(key, cloneCode)
+        await this.updateKeeperConfigCloneCode(String(host), username, cloneCode)
+    }
+
+    private async updateKeeperConfigCloneCode(host: string, username: string, cloneCode: Uint8Array): Promise<void> {
+        try {
+            const parsed = await this.configLoader.load()
+            if (!parsed || Object.keys(parsed).length === 0) return
+
+            let updated = false
+            const encodedCloneCode = Buffer.from(cloneCode).toString('base64url')
+
+            const server = parsed.last_server || parsed.server
+            if (parsed.user?.toLowerCase() === username.toLowerCase() && server === host) {
+                parsed.clone_code = encodedCloneCode
+                updated = true
+            }
+
+            const user = (parsed.users || []).find(
+                u => u.user?.toLowerCase() === username.toLowerCase()
+            )
+            if (user?.last_device?.device_token) {
+                const device = (parsed.devices || []).find(
+                    d => d.device_token === user.last_device.device_token
+                )
+                if (device?.server_info) {
+                    const serverInfo = device.server_info.find(si => si.server === host)
+                    if (serverInfo) {
+                        serverInfo.clone_code = encodedCloneCode
+                        updated = true
+                    }
+                }
+            }
+
+            if (updated) {
+                await this.configLoader.save(parsed)
+                this._keeperConfig = null
+                this._deviceCache = null
+            }
+        } catch (err) {
+            logger.warn('Failed to update keeper config clone code:', extractErrorMessage(err))
+        }
+    }
+
+    public async getSessionParameters(): Promise<SessionParams | null> {
+        return this.sessionParams
+    }
+
+    public async saveSessionParameters(params: Partial<SessionParams>): Promise<void> {
+        this.sessionParams = { ...this.sessionParams, ...params } as SessionParams
+        if (params.username) {
+            this._lastUsername = params.username
+        }
+    }
+
+    public setLastUsername(username: string): void {
+        this._lastUsername = username
+    }
+
+    private async loadKeeperConfig(): Promise<KeeperJsonConfig> {
+        if (this._keeperConfig) return this._keeperConfig
+        this._keeperConfig = await this.configLoader.load()
+        return this._keeperConfig
+    }
+
+    private async findDeviceInKeeperConfig(username: string): Promise<ResolvedDevice | null> {
+        const normalizedUsername = username.toLowerCase()
+        if (this._deviceCache?.username === normalizedUsername) {
+            return this._deviceCache.device
+        }
+
+        const device = await this.lookupDeviceInKeeperConfig(normalizedUsername)
+        this._deviceCache = { username: normalizedUsername, device }
+        return device
+    }
+
+    private async lookupDeviceInKeeperConfig(normalizedUsername: string): Promise<ResolvedDevice | null> {
+        const kc = await this.loadKeeperConfig()
+
+        if (kc.device_token && kc.private_key && kc.user?.toLowerCase() === normalizedUsername) {
+            const serverInfo: Array<Required<ConfigurationServerConfig>> = []
+            const server = kc.last_server || kc.server
+            if (server && kc.clone_code) {
+                serverInfo.push({ server, clone_code: kc.clone_code })
+            }
+            return {
+                deviceToken: SessionManager.base64urlDecode(kc.device_token),
+                privateKey: SessionManager.base64urlDecode(kc.private_key),
+                serverInfo,
+            }
+        }
+
+        if (kc.users && kc.devices) {
+            const user = kc.users.find(u => u.user?.toLowerCase() === normalizedUsername)
+            if (user?.last_device?.device_token) {
+                const deviceTokenStr = user.last_device.device_token
+                const device = kc.devices.find(d => d.device_token === deviceTokenStr)
+                if (device?.private_key) {
+                    return {
+                        deviceToken: SessionManager.base64urlDecode(deviceTokenStr),
+                        privateKey: SessionManager.base64urlDecode(device.private_key),
+                        serverInfo: (device.server_info || [])
+                            .filter((si): si is Required<ConfigurationServerConfig> =>
+                                !!si.server && !!si.clone_code
+                            ),
+                    }
+                }
+            }
+        }
+
+        return null
+    }
+
+    public static isValidKeeperConfig(value: unknown): value is KeeperJsonConfig {
+        if (typeof value !== 'object' || value === null) return false
+        const obj = value as Record<string, unknown>
+        if (obj.users !== undefined && !Array.isArray(obj.users)) return false
+        if (obj.devices !== undefined && !Array.isArray(obj.devices)) return false
+        return true
+    }
+
+    private static base64urlDecode(str: string): Buffer {
+        return Buffer.from(str.replace(/-/g, '+').replace(/_/g, '/'), 'base64')
+    }
+}

--- a/KeeperSdk/src/index.ts
+++ b/KeeperSdk/src/index.ts
@@ -1,0 +1,89 @@
+export { ConsoleAuthUI } from './auth/ConsoleAuthUI'
+export { SessionManager, FileConfigLoader } from './auth/SessionManager'
+export type {
+    KeeperJsonConfig,
+    ConfigLoader,
+    ConfigurationUser,
+    ConfigurationServerConfig,
+    ConfigurationDeviceConfig,
+} from './auth/SessionManager'
+export {
+    login,
+    cleanup,
+    prompt,
+    suppressLogs,
+    loadKeeperConfig,
+    resolveServer,
+} from './auth/ConsoleLogin'
+
+export { InMemoryStorage } from './storage/InMemoryStorage'
+
+export {
+    Logger, ConsoleLogger, LogLevel, logger, setLogger, getLogger, resetLogger,
+    KeeperSdkError, isKeeperError, extractErrorMessage, extractResultCode,
+    SdkDefaults, AuthDefaults, ResultCodes, KEEPER_PUBLIC_HOSTS,
+} from './utils'
+export type { ILogger } from './utils'
+
+export {
+    searchRecords,
+    formatRecord,
+    getRecordTitle,
+    getRecordType,
+    getRecordFields,
+    getRecordSummary,
+    getRecordPassword,
+    getRecordLogin,
+    getRecordUrl,
+    RecordVersion,
+} from './records/RecordUtils'
+export type { RecordSummary } from './records/RecordUtils'
+export { addRecord, updateRecord, deleteRecord, getRecordHistory, moveRecord } from './records/RecordOperations'
+export type {
+    PasswordRecordData,
+    TypedRecordData,
+    RecordFieldInput,
+    NewRecordInput,
+    AddRecordResult,
+    UpdateRecordResult,
+    DeleteRecordResult,
+    HistoryEntry,
+    RecordHistoryResult,
+    MoveRecordInput,
+    MoveRecordResult,
+} from './records/RecordOperations'
+
+export { shareRecord, removeRecordShare } from './sharing/Sharing'
+export type {
+    ShareRecordInput,
+    ShareRecordResult,
+    RemoveShareInput,
+    RemoveShareResult,
+} from './sharing/Sharing'
+
+export { KeeperVault } from './vault/KeeperVault'
+export type { KeeperVaultConfig, VaultSummary } from './vault/KeeperVault'
+
+export {
+    Auth,
+    KeeperEnvironment,
+    syncDown,
+    Authentication,
+} from '@keeper-security/keeperapi'
+
+export type {
+    DRecord,
+    DRecordMetadata,
+    DSharedFolder,
+    DTeam,
+    DUserFolder,
+    VaultStorage,
+    SyncResult,
+    SyncDownOptions,
+    ClientConfiguration,
+    DeviceConfig,
+    SessionStorage,
+    AuthUI3,
+    KeeperError,
+    LoginError,
+} from '@keeper-security/keeperapi'

--- a/KeeperSdk/src/records/RecordOperations.ts
+++ b/KeeperSdk/src/records/RecordOperations.ts
@@ -67,6 +67,25 @@ export type PasswordRecordData = {
     url?: string
     notes?: string
     custom?: { name: string; value: string; type?: string }[]
+    totp?: string
+}
+
+function buildLegacyPasswordExtra(data: PasswordRecordData, recordUid: string): Record<string, unknown> {
+    const totp = data.totp?.trim()
+    if (!totp) {
+        return {}
+    }
+    return {
+        files: [],
+        fields: [
+            {
+                id: recordUid,
+                field_type: 'totp',
+                field_title: 'One-Time Password',
+                data: totp,
+            },
+        ],
+    }
 }
 
 export type RecordFieldInput = {
@@ -143,7 +162,7 @@ async function addPasswordRecord(
         })),
     })
 
-    const extraJson = JSON.stringify({})
+    const extraJson = JSON.stringify(buildLegacyPasswordExtra(data, recordUid))
 
     const dataBytes = new TextEncoder().encode(recordDataJson)
     const extraBytes = new TextEncoder().encode(extraJson)

--- a/KeeperSdk/src/records/RecordOperations.ts
+++ b/KeeperSdk/src/records/RecordOperations.ts
@@ -11,6 +11,8 @@ import {
     recordDeleteCommand,
     recordAddCommand,
     moveCommand,
+    getRecordHistoryCommand,
+    normal64Bytes,
 } from '@keeper-security/keeperapi'
 import type {
     DSharedFolder,
@@ -18,14 +20,12 @@ import type {
     DSharedFolderRecord,
     DUserFolder,
     DRecord,
-    KeeperResponse,
     KeeperPreDeleteResponse,
     MoveObject,
     MoveRequest,
     TransitionKeyObject,
     RecordPreDeleteObject,
-    RestCommand,
-    BaseRequest,
+    GetRecordHistoryResponse,
 } from '@keeper-security/keeperapi'
 import { extractErrorMessage, KeeperSdkError, logger } from '../utils'
 import { RecordVersion } from './RecordUtils'
@@ -48,10 +48,6 @@ enum DeleteResolution {
 enum ResultCode {
     Success = 'success',
     OK = 'OK',
-}
-
-enum CommandName {
-    GetRecordHistory = 'get_record_history',
 }
 
 const MIN_RECORD_PAD_BYTES = 384
@@ -209,7 +205,7 @@ async function addTypedRecord(
     }
 
     if (folderUid) {
-        recordAdd.folderUid = platform.base64ToBytes(folderUid)
+        recordAdd.folderUid = normal64Bytes(folderUid)
     }
 
     const request: Records.IRecordsAddRequest = {
@@ -247,7 +243,7 @@ export async function updateRecord(
     if (!data.type?.trim()) {
         throw new KeeperSdkError('Record type is required.', 'missing_record_type')
     }
-    const recordUidBytes = platform.base64ToBytes(recordUid)
+    const recordUidBytes = normal64Bytes(recordUid)
 
     const recordPayload = {
         type: data.type,
@@ -345,38 +341,17 @@ export type RecordHistoryResult = {
     history: HistoryEntry[]
 }
 
-type RecordHistoryRequest = {
-    record_uid: string
-    client_time: number
-}
-
-type RecordHistoryResponseEntry = {
-    revision: number
-    version: number
-    user_name?: string
-    client_modified_time?: number
-    data?: string
-}
-
-type RecordHistoryResponse = KeeperResponse & {
-    history?: RecordHistoryResponseEntry[]
-}
-
 export async function getRecordHistory(
     auth: Auth,
     recordUid: string,
     recordKey: Uint8Array
 ): Promise<RecordHistoryResult> {
-    const cmd: RestCommand<RecordHistoryRequest, RecordHistoryResponse> = {
-        baseRequest: { command: CommandName.GetRecordHistory } as BaseRequest,
-        request: {
-            record_uid: recordUid,
-            client_time: Date.now(),
-        },
-        authorization: {},
-    }
+    const cmd = getRecordHistoryCommand({
+        record_uid: recordUid,
+        client_time: Date.now(),
+    })
 
-    let response: RecordHistoryResponse
+    let response: GetRecordHistoryResponse
     try {
         response = await auth.executeRestCommand(cmd)
     } catch (err) {
@@ -391,9 +366,7 @@ export async function getRecordHistory(
 
         if (entry.data) {
             try {
-                const dataBytes = platform.base64ToBytes(
-                    normalizeBase64(entry.data)
-                )
+                const dataBytes = normal64Bytes(entry.data)
                 const version = entry.version || 0
                 let decrypted: Uint8Array
 
@@ -420,11 +393,6 @@ export async function getRecordHistory(
     }
 
     return { recordUid, history }
-}
-
-function normalizeBase64(source: string): string {
-    return source.replace(/-/g, '+').replace(/_/g, '/')
-        + '=='.substring(0, (3 * source.length) % 4)
 }
 
 export type MoveRecordInput = {

--- a/KeeperSdk/src/records/RecordOperations.ts
+++ b/KeeperSdk/src/records/RecordOperations.ts
@@ -1,0 +1,566 @@
+import {
+    Auth,
+    Records,
+    platform,
+    generateEncryptionKey,
+    generateUidBytes,
+    webSafe64FromBytes,
+    recordsAddMessage,
+    recordsUpdateMessage,
+    recordPreDeleteCommand,
+    recordDeleteCommand,
+    recordAddCommand,
+    moveCommand,
+} from '@keeper-security/keeperapi'
+import type {
+    DSharedFolder,
+    DSharedFolderFolder,
+    DSharedFolderRecord,
+    DUserFolder,
+    DRecord,
+    KeeperResponse,
+    KeeperPreDeleteResponse,
+    MoveObject,
+    MoveRequest,
+    TransitionKeyObject,
+    RecordPreDeleteObject,
+    RestCommand,
+    BaseRequest,
+} from '@keeper-security/keeperapi'
+import { extractErrorMessage, KeeperSdkError, logger } from '../utils'
+import { RecordVersion } from './RecordUtils'
+import { InMemoryStorage } from '../storage/InMemoryStorage'
+
+enum FolderType {
+    UserFolder = 'user_folder',
+    SharedFolder = 'shared_folder',
+    SharedFolderFolder = 'shared_folder_folder',
+}
+
+enum ObjectType {
+    Record = 'record',
+}
+
+enum DeleteResolution {
+    Unlink = 'unlink',
+}
+
+enum ResultCode {
+    Success = 'success',
+    OK = 'OK',
+}
+
+enum CommandName {
+    GetRecordHistory = 'get_record_history',
+}
+
+const MIN_RECORD_PAD_BYTES = 384
+const PAD_BLOCK_SIZE = 16
+
+function getPaddedJsonBytes(data: Record<string, any>): Uint8Array {
+    const json = JSON.stringify(data)
+    const paddedLength = Math.ceil(Math.max(MIN_RECORD_PAD_BYTES, json.length) / PAD_BLOCK_SIZE) * PAD_BLOCK_SIZE
+    const padded = json.padEnd(paddedLength, ' ')
+    return new TextEncoder().encode(padded)
+}
+
+export type PasswordRecordData = {
+    title: string
+    login?: string
+    password?: string
+    url?: string
+    notes?: string
+    custom?: { name: string; value: string; type?: string }[]
+}
+
+export type RecordFieldInput = {
+    type: string
+    value: any[]
+    label?: string
+}
+
+export type TypedRecordData = {
+    type: string
+    title: string
+    fields?: RecordFieldInput[]
+    custom?: RecordFieldInput[]
+    notes?: string
+}
+
+export type NewRecordInput =
+    | { version: 2; data: PasswordRecordData; folderUid?: string }
+    | { version: 3; data: TypedRecordData; folderUid?: string }
+
+export type AddRecordResult = {
+    recordUid: string
+    success: boolean
+    status?: string
+}
+
+export type UpdateRecordResult = {
+    recordUid: string
+    success: boolean
+    status?: string
+}
+
+export type DeleteRecordResult = {
+    recordUid: string
+    success: boolean
+    message?: string
+}
+
+export async function addRecord(
+    auth: Auth,
+    input: NewRecordInput
+): Promise<AddRecordResult> {
+    if (!input.data.title || !input.data.title.trim()) {
+        throw new KeeperSdkError('Record title is required.', 'missing_record_title')
+    }
+    if (input.version === 3 && !input.data.type?.trim()) {
+        throw new KeeperSdkError('Record type is required for v3 records.', 'missing_record_type')
+    }
+    if (input.version === 2) {
+        return addPasswordRecord(auth, input.data, input.folderUid)
+    }
+    return addTypedRecord(auth, input.data, input.folderUid)
+}
+
+async function addPasswordRecord(
+    auth: Auth,
+    data: PasswordRecordData,
+    folderUid?: string
+): Promise<AddRecordResult> {
+    const recordUidBytes = generateUidBytes()
+    const recordKey = generateEncryptionKey()
+    const recordUid = webSafe64FromBytes(recordUidBytes)
+
+    const recordDataJson = JSON.stringify({
+        title: data.title || '',
+        secret1: data.login || '',
+        secret2: data.password || '',
+        link: data.url || '',
+        notes: data.notes || '',
+        custom: (data.custom || []).map((c) => ({
+            name: c.name,
+            value: c.value,
+            type: c.type || 'text',
+        })),
+    })
+
+    const extraJson = JSON.stringify({})
+
+    const dataBytes = new TextEncoder().encode(recordDataJson)
+    const extraBytes = new TextEncoder().encode(extraJson)
+
+    const encryptedData = await platform.aesCbcEncrypt(dataBytes, recordKey, true)
+    const encryptedExtra = await platform.aesCbcEncrypt(extraBytes, recordKey, true)
+    const encryptedRecordKey = await platform.aesCbcEncrypt(recordKey, auth.dataKey!, true)
+
+    const cmd = recordAddCommand({
+        record_uid: recordUid,
+        record_key: webSafe64FromBytes(encryptedRecordKey),
+        record_type: 'password',
+        folder_type: FolderType.UserFolder,
+        how_long_ago: 0,
+        folder_uid: folderUid || '',
+        folder_key: '',
+        data: webSafe64FromBytes(encryptedData),
+        extra: webSafe64FromBytes(encryptedExtra),
+        non_shared_data: '',
+        file_ids: [],
+    })
+
+    const response = await auth.executeRestCommand(cmd)
+
+    return {
+        recordUid,
+        success: response.result_code === ResultCode.Success,
+        status: response.result_code,
+    }
+}
+
+async function addTypedRecord(
+    auth: Auth,
+    data: TypedRecordData,
+    folderUid?: string
+): Promise<AddRecordResult> {
+    const recordUidBytes = generateUidBytes()
+    const recordKey = generateEncryptionKey()
+    const recordUid = webSafe64FromBytes(recordUidBytes)
+
+    const recordPayload = {
+        type: data.type,
+        title: data.title,
+        fields: data.fields || [],
+        custom: data.custom || [],
+        notes: data.notes || '',
+    }
+
+    const dataBytes = getPaddedJsonBytes(recordPayload)
+    const encryptedData = await platform.aesGcmEncrypt(dataBytes, recordKey)
+    const encryptedRecordKey = await platform.aesGcmEncrypt(recordKey, auth.dataKey!)
+
+    const recordAdd: Records.IRecordAdd = {
+        recordUid: recordUidBytes,
+        recordKey: encryptedRecordKey,
+        clientModifiedTime: Date.now(),
+        data: encryptedData,
+        folderType: Records.RecordFolderType.user_folder,
+    }
+
+    if (folderUid) {
+        recordAdd.folderUid = platform.base64ToBytes(folderUid)
+    }
+
+    const request: Records.IRecordsAddRequest = {
+        records: [recordAdd],
+        clientTime: Date.now(),
+    }
+
+    const msg = recordsAddMessage(request)
+    const response = await auth.executeRest(msg)
+
+    const recordStatus = response.records?.[0]
+    const success =
+        recordStatus?.status === Records.RecordModifyResult.RS_SUCCESS ||
+        !recordStatus?.status
+
+    return {
+        recordUid,
+        success,
+        status: recordStatus?.status != null
+            ? Records.RecordModifyResult[recordStatus.status]
+            : ResultCode.OK,
+    }
+}
+
+export async function updateRecord(
+    auth: Auth,
+    recordUid: string,
+    data: TypedRecordData,
+    revision: number,
+    recordKey: Uint8Array
+): Promise<UpdateRecordResult> {
+    if (!data.title || !data.title.trim()) {
+        throw new KeeperSdkError('Record title is required.', 'missing_record_title')
+    }
+    if (!data.type?.trim()) {
+        throw new KeeperSdkError('Record type is required.', 'missing_record_type')
+    }
+    const recordUidBytes = platform.base64ToBytes(recordUid)
+
+    const recordPayload = {
+        type: data.type,
+        title: data.title,
+        fields: data.fields || [],
+        custom: data.custom || [],
+        notes: data.notes || '',
+    }
+
+    const dataBytes = getPaddedJsonBytes(recordPayload)
+    const encryptedData = await platform.aesGcmEncrypt(dataBytes, recordKey)
+
+    const recordUpdate: Records.IRecordUpdate = {
+        recordUid: recordUidBytes,
+        clientModifiedTime: Date.now(),
+        revision,
+        data: encryptedData,
+    }
+
+    const request: Records.IRecordsUpdateRequest = {
+        records: [recordUpdate],
+        clientTime: Date.now(),
+    }
+
+    const msg = recordsUpdateMessage(request)
+    const response = await auth.executeRest(msg)
+
+    const recordStatus = response.records?.[0]
+    const success =
+        recordStatus?.status === Records.RecordModifyResult.RS_SUCCESS ||
+        !recordStatus?.status
+
+    return {
+        recordUid,
+        success,
+        status: recordStatus?.status != null
+            ? Records.RecordModifyResult[recordStatus.status]
+            : ResultCode.OK,
+    }
+}
+
+export async function deleteRecord(
+    auth: Auth,
+    recordUid: string
+): Promise<DeleteRecordResult> {
+    const preDeleteRequest = {
+        objects: [
+            {
+                object_uid: recordUid,
+                object_type: ObjectType.Record,
+                from_uid: '',
+                from_type: FolderType.UserFolder,
+                delete_resolution: DeleteResolution.Unlink,
+            } as RecordPreDeleteObject,
+        ],
+    }
+
+    let preDeleteResponse: KeeperPreDeleteResponse
+    try {
+        const preDeleteCmd = recordPreDeleteCommand(preDeleteRequest)
+        preDeleteResponse = await auth.executeRestCommand(preDeleteCmd)
+    } catch (err) {
+        return { recordUid, success: false, message: extractErrorMessage(err) }
+    }
+
+    const token = preDeleteResponse?.pre_delete_response?.pre_delete_token
+    if (!token) {
+        return {
+            recordUid,
+            success: false,
+            message: preDeleteResponse?.message || preDeleteResponse?.result_code || 'pre_delete failed: no token',
+        }
+    }
+
+    try {
+        const deleteCmd = recordDeleteCommand({ pre_delete_token: token })
+        await auth.executeRestCommand(deleteCmd)
+    } catch (err) {
+        return { recordUid, success: false, message: extractErrorMessage(err) }
+    }
+
+    return { recordUid, success: true, message: ResultCode.Success }
+}
+
+export type HistoryEntry = {
+    revision: number
+    version: number
+    userName: string
+    clientModifiedTime: number
+    data: Record<string, any> | null
+}
+
+export type RecordHistoryResult = {
+    recordUid: string
+    history: HistoryEntry[]
+}
+
+type RecordHistoryRequest = {
+    record_uid: string
+    client_time: number
+}
+
+type RecordHistoryResponseEntry = {
+    revision: number
+    version: number
+    user_name?: string
+    client_modified_time?: number
+    data?: string
+}
+
+type RecordHistoryResponse = KeeperResponse & {
+    history?: RecordHistoryResponseEntry[]
+}
+
+export async function getRecordHistory(
+    auth: Auth,
+    recordUid: string,
+    recordKey: Uint8Array
+): Promise<RecordHistoryResult> {
+    const cmd: RestCommand<RecordHistoryRequest, RecordHistoryResponse> = {
+        baseRequest: { command: CommandName.GetRecordHistory } as BaseRequest,
+        request: {
+            record_uid: recordUid,
+            client_time: Date.now(),
+        },
+        authorization: {},
+    }
+
+    let response: RecordHistoryResponse
+    try {
+        response = await auth.executeRestCommand(cmd)
+    } catch (err) {
+        throw KeeperSdkError.from(err)
+    }
+
+    const rawHistory = response.history || []
+    const history: HistoryEntry[] = []
+
+    for (const entry of rawHistory) {
+        let decryptedData: Record<string, any> | null = null
+
+        if (entry.data) {
+            try {
+                const dataBytes = platform.base64ToBytes(
+                    normalizeBase64(entry.data)
+                )
+                const version = entry.version || 0
+                let decrypted: Uint8Array
+
+                if (version <= RecordVersion.Legacy) {
+                    decrypted = await platform.aesCbcDecrypt(dataBytes, recordKey, true)
+                } else {
+                    decrypted = await platform.aesGcmDecrypt(dataBytes, recordKey)
+                }
+
+                decryptedData = JSON.parse(platform.bytesToString(decrypted))
+            } catch (err) {
+                logger.debug(`Failed to decrypt history revision ${entry.revision}:`, extractErrorMessage(err))
+                decryptedData = null
+            }
+        }
+
+        history.push({
+            revision: entry.revision,
+            version: entry.version,
+            userName: entry.user_name || '',
+            clientModifiedTime: entry.client_modified_time || 0,
+            data: decryptedData,
+        })
+    }
+
+    return { recordUid, history }
+}
+
+function normalizeBase64(source: string): string {
+    return source.replace(/-/g, '+').replace(/_/g, '/')
+        + '=='.substring(0, (3 * source.length) % 4)
+}
+
+export type MoveRecordInput = {
+    recordUid: string
+    dstFolderUid: string
+    srcFolderUid?: string
+    link?: boolean
+    canEdit?: boolean
+    canShare?: boolean
+}
+
+export type MoveRecordResult = {
+    recordUid: string
+    success: boolean
+    message: string
+}
+
+type FolderInfo = {
+    uid: string
+    folderType: FolderType
+    scopeUid: string
+}
+
+function resolveFolder(uid: string, storage: InMemoryStorage): FolderInfo {
+    if (!uid) {
+        return { uid: '', folderType: FolderType.UserFolder, scopeUid: '' }
+    }
+
+    if (storage.getByUid<DUserFolder>(FolderType.UserFolder, uid)) {
+        return { uid, folderType: FolderType.UserFolder, scopeUid: '' }
+    }
+
+    if (storage.getByUid<DSharedFolder>(FolderType.SharedFolder, uid)) {
+        return { uid, folderType: FolderType.SharedFolder, scopeUid: uid }
+    }
+
+    const sfFolder = storage.getByUid<DSharedFolderFolder>(FolderType.SharedFolderFolder, uid)
+    if (sfFolder) {
+        return { uid, folderType: FolderType.SharedFolderFolder, scopeUid: sfFolder.sharedFolderUid }
+    }
+
+    return { uid, folderType: FolderType.UserFolder, scopeUid: '' }
+}
+
+function findRecordSourceFolder(
+    recordUid: string,
+    storage: InMemoryStorage
+): { folderUid: string; folderType: FolderType } {
+    const sfRecords = storage.getAll<DSharedFolderRecord>('shared_folder_record')
+    const sfr = sfRecords.find((r) => r.recordUid === recordUid)
+    if (sfr) {
+        return { folderUid: sfr.sharedFolderUid, folderType: FolderType.SharedFolder }
+    }
+
+    return { folderUid: '', folderType: FolderType.UserFolder }
+}
+
+export async function moveRecord(
+    auth: Auth,
+    storage: InMemoryStorage,
+    input: MoveRecordInput
+): Promise<MoveRecordResult> {
+    const {
+        recordUid,
+        dstFolderUid,
+        link = false,
+        canEdit,
+        canShare,
+    } = input
+
+    const dst = resolveFolder(dstFolderUid, storage)
+
+    let src: FolderInfo
+    if (input.srcFolderUid !== undefined) {
+        src = resolveFolder(input.srcFolderUid, storage)
+    } else {
+        const found = findRecordSourceFolder(recordUid, storage)
+        src = resolveFolder(found.folderUid, storage)
+    }
+
+    const moveObj: MoveObject = {
+        uid: recordUid,
+        type: ObjectType.Record,
+        cascade: false,
+        from_type: src.folderType,
+        from_uid: src.uid || undefined,
+        can_edit: canEdit,
+        can_reshare: canShare,
+    }
+
+    const transitionKeys: TransitionKeyObject[] = []
+
+    if (src.scopeUid !== dst.scopeUid) {
+        const recordKey = await storage.getKeyBytes(recordUid)
+        if (!recordKey) {
+            return { recordUid, success: false, message: 'Record key not found' }
+        }
+
+        let dstKey: Uint8Array | undefined
+        if (dst.scopeUid) {
+            dstKey = await storage.getKeyBytes(dst.scopeUid)
+        } else {
+            dstKey = auth.dataKey
+        }
+
+        if (!dstKey) {
+            return { recordUid, success: false, message: 'Destination folder key not found' }
+        }
+
+        const record = storage.getByUid<DRecord>(ObjectType.Record, recordUid)
+        const version = record?.version || RecordVersion.Typed
+
+        let encryptedKey: Uint8Array
+        if (version >= RecordVersion.Typed) {
+            encryptedKey = await platform.aesGcmEncrypt(recordKey, dstKey)
+        } else {
+            encryptedKey = await platform.aesCbcEncrypt(recordKey, dstKey, true)
+        }
+
+        transitionKeys.push({ uid: recordUid, key: webSafe64FromBytes(encryptedKey) })
+    }
+
+    const request: MoveRequest = {
+        to_type: dst.folderType,
+        to_uid: dst.uid || undefined,
+        link,
+        move: [moveObj],
+        transition_keys: transitionKeys,
+    }
+
+    try {
+        const cmd = moveCommand(request)
+        await auth.executeRestCommand(cmd)
+    } catch (err) {
+        return { recordUid, success: false, message: extractErrorMessage(err) }
+    }
+
+    return { recordUid, success: true, message: 'Record moved successfully' }
+}

--- a/KeeperSdk/src/records/RecordUtils.ts
+++ b/KeeperSdk/src/records/RecordUtils.ts
@@ -1,0 +1,189 @@
+import type { DRecord } from '@keeper-security/keeperapi'
+
+enum FieldType {
+    Login = 'login',
+    Password = 'password',
+    Url = 'url',
+    Note = 'note',
+    Text = 'text',
+}
+
+export enum RecordVersion {
+    Legacy = 2,
+    Typed = 3,
+}
+
+type RecordField = {
+    type: string
+    value: any[]
+    label?: string
+}
+
+export function getRecordTitle(record: DRecord): string {
+    if (!record.data) return '(no data)'
+    if (typeof record.data === 'string') {
+        try {
+            const parsed = JSON.parse(record.data)
+            return parsed.title || parsed.name || '(untitled)'
+        } catch (_err) {
+            return '(parse error)'
+        }
+    }
+    return record.data.title || record.data.name || '(untitled)'
+}
+
+export function getRecordType(record: DRecord): string {
+    if (record.version <= RecordVersion.Legacy) return 'legacy'
+    if (!record.data) return 'unknown'
+    return record.data.type || 'unknown'
+}
+
+export function getRecordFields(record: DRecord): RecordField[] {
+    if (!record.data) return []
+
+    if (record.version <= RecordVersion.Legacy) {
+        const fields: RecordField[] = []
+        const d = record.data
+        if (d.secret1) fields.push({ type: FieldType.Login, value: [d.secret1] })
+        if (d.secret2) fields.push({ type: FieldType.Password, value: [d.secret2] })
+        if (d.link) fields.push({ type: FieldType.Url, value: [d.link] })
+        if (d.notes) fields.push({ type: FieldType.Note, value: [d.notes] })
+        return fields
+    }
+
+    const fields: RecordField[] = []
+    if (Array.isArray(record.data.fields)) {
+        for (const f of record.data.fields) {
+            fields.push({
+                type: f.type || FieldType.Text,
+                value: Array.isArray(f.value) ? f.value : [f.value],
+                label: f.label,
+            })
+        }
+    }
+    if (Array.isArray(record.data.custom)) {
+        for (const f of record.data.custom) {
+            fields.push({
+                type: f.type || FieldType.Text,
+                value: Array.isArray(f.value) ? f.value : [f.value],
+                label: f.label,
+            })
+        }
+    }
+    return fields
+}
+
+export type RecordSummary = {
+    login?: string
+    password?: string
+    url?: string
+    fields: RecordField[]
+}
+
+export function getRecordSummary(record: DRecord): RecordSummary {
+    const fields = getRecordFields(record)
+    if (record.version <= RecordVersion.Legacy) {
+        return {
+            login: record.data?.secret1,
+            password: record.data?.secret2,
+            url: record.data?.link,
+            fields,
+        }
+    }
+
+    let login: string | undefined
+    let password: string | undefined
+    let url: string | undefined
+
+    for (const f of fields) {
+        if (!login && f.type === FieldType.Login && f.value.length > 0) {
+            login = String(f.value[0])
+        } else if (!password && f.type === FieldType.Password && f.value.length > 0) {
+            password = String(f.value[0])
+        } else if (!url && f.type === FieldType.Url && f.value.length > 0) {
+            const val = f.value[0]
+            url = typeof val === 'string' ? val : val?.value || val?.url
+        }
+    }
+
+    return { login, password, url, fields }
+}
+
+export function getRecordPassword(record: DRecord): string | undefined {
+    return getRecordSummary(record).password
+}
+
+export function getRecordLogin(record: DRecord): string | undefined {
+    return getRecordSummary(record).login
+}
+
+export function getRecordUrl(record: DRecord): string | undefined {
+    return getRecordSummary(record).url
+}
+
+const wordCache = new WeakMap<DRecord, string[]>()
+
+export function searchRecords(records: DRecord[], criteria: string): DRecord[] {
+    if (!criteria.trim()) return records
+
+    const searchWords = criteria.toLowerCase().split(/\s+/)
+
+    return records.filter((record) => {
+        let words = wordCache.get(record)
+        if (!words) {
+            words = collectRecordWords(record)
+            wordCache.set(record, words)
+        }
+        return searchWords.every((sw) => words!.some((w) => w.includes(sw)))
+    })
+}
+
+function collectRecordWords(record: DRecord): string[] {
+    const words: string[] = []
+    const title = getRecordTitle(record)
+    if (title) words.push(...title.toLowerCase().split(/\s+/))
+
+    for (const field of getRecordFields(record)) {
+        if (field.label) words.push(field.label.toLowerCase())
+        for (const v of field.value) {
+            if (typeof v === 'string') {
+                words.push(...v.toLowerCase().split(/\s+/))
+            } else if (v && typeof v === 'object') {
+                for (const val of Object.values(v)) {
+                    if (typeof val === 'string') {
+                        words.push(...val.toLowerCase().split(/\s+/))
+                    }
+                }
+            }
+        }
+    }
+
+    words.push(record.uid)
+    return words
+}
+
+export function formatRecord(record: DRecord, showDetails = false): string {
+    const title = getRecordTitle(record)
+    const type = getRecordType(record)
+    const summary = getRecordSummary(record)
+    const lines: string[] = []
+
+    lines.push('-'.repeat(50))
+    lines.push(`Title: ${title}`)
+    lines.push(`Record UID: ${record.uid}`)
+    lines.push(`Record Type: ${type}`)
+
+    if (summary.login) lines.push(`Username: ${summary.login}`)
+    if (summary.url) lines.push(`URL: ${summary.url}`)
+
+    if (showDetails) {
+        for (const field of summary.fields) {
+            if (field.type === FieldType.Login || field.type === FieldType.Url) continue
+            const label = field.label || field.type
+            const value = field.type === FieldType.Password ? '********' : field.value.join(', ')
+            lines.push(`${label}: ${value}`)
+        }
+    }
+
+    return lines.join('\n')
+}

--- a/KeeperSdk/src/records/RecordUtils.ts
+++ b/KeeperSdk/src/records/RecordUtils.ts
@@ -17,6 +17,43 @@ type RecordField = {
     type: string
     value: any[]
     label?: string
+    required?: boolean
+    privacyScreen?: boolean
+    enforceGeneration?: boolean
+    complexity?: {
+        length?: number
+        caps?: number
+        lowercase?: number
+        digits?: number
+        special?: number
+    }
+}
+
+function getLegacyExtraFields(record: DRecord): RecordField[] {
+    const raw = record.extra
+    if (raw == null) return []
+    let extra: { fields?: { type?: string; value?: unknown; label?: string }[] }
+    if (typeof raw === 'string') {
+        try {
+            extra = JSON.parse(raw)
+        } catch {
+            return []
+        }
+    } else if (typeof raw === 'object') {
+        extra = raw
+    } else {
+        return []
+    }
+    if (!Array.isArray(extra.fields)) return []
+    const out: RecordField[] = []
+    for (const f of extra.fields) {
+        out.push({
+            type: f.type || FieldType.Text,
+            value: Array.isArray(f.value) ? f.value : f.value != null ? [f.value] : [],
+            label: f.label,
+        })
+    }
+    return out
 }
 
 export function getRecordTitle(record: DRecord): string {
@@ -24,12 +61,12 @@ export function getRecordTitle(record: DRecord): string {
     if (typeof record.data === 'string') {
         try {
             const parsed = JSON.parse(record.data)
-            return parsed.title || parsed.name || '(untitled)'
+            return parsed.title || '(untitled)'
         } catch (_err) {
             return '(parse error)'
         }
     }
-    return record.data.title || record.data.name || '(untitled)'
+    return record.data.title || '(untitled)'
 }
 
 export function getRecordType(record: DRecord): string {
@@ -48,6 +85,8 @@ export function getRecordFields(record: DRecord): RecordField[] {
         if (d.secret2) fields.push({ type: FieldType.Password, value: [d.secret2] })
         if (d.link) fields.push({ type: FieldType.Url, value: [d.link] })
         if (d.notes) fields.push({ type: FieldType.Note, value: [d.notes] })
+        const extraFields = getLegacyExtraFields(record)
+        fields.push(...extraFields)
         return fields
     }
 
@@ -58,6 +97,10 @@ export function getRecordFields(record: DRecord): RecordField[] {
                 type: f.type || FieldType.Text,
                 value: Array.isArray(f.value) ? f.value : [f.value],
                 label: f.label,
+                required: f.required,
+                privacyScreen: f.privacyScreen,
+                enforceGeneration: f.enforceGeneration,
+                complexity: f.complexity,
             })
         }
     }
@@ -67,6 +110,10 @@ export function getRecordFields(record: DRecord): RecordField[] {
                 type: f.type || FieldType.Text,
                 value: Array.isArray(f.value) ? f.value : [f.value],
                 label: f.label,
+                required: f.required,
+                privacyScreen: f.privacyScreen,
+                enforceGeneration: f.enforceGeneration,
+                complexity: f.complexity,
             })
         }
     }

--- a/KeeperSdk/src/records/RecordUtils.ts
+++ b/KeeperSdk/src/records/RecordUtils.ts
@@ -29,10 +29,24 @@ type RecordField = {
     }
 }
 
+type LegacyExtraField = {
+    type?: string
+    field_type?: string
+    value?: unknown
+    data?: unknown
+    label?: string
+    field_title?: string
+}
+
+function toFieldValueArray(v: unknown): any[] {
+    if (v == null) return []
+    return Array.isArray(v) ? v : [v]
+}
+
 function getLegacyExtraFields(record: DRecord): RecordField[] {
     const raw = record.extra
     if (raw == null) return []
-    let extra: { fields?: { type?: string; value?: unknown; label?: string }[] }
+    let extra: { fields?: LegacyExtraField[] }
     if (typeof raw === 'string') {
         try {
             extra = JSON.parse(raw)
@@ -47,10 +61,12 @@ function getLegacyExtraFields(record: DRecord): RecordField[] {
     if (!Array.isArray(extra.fields)) return []
     const out: RecordField[] = []
     for (const f of extra.fields) {
+        const typeName = f.type || f.field_type || FieldType.Text
+        const rawVal = f.value !== undefined && f.value !== null ? f.value : f.data
         out.push({
-            type: f.type || FieldType.Text,
-            value: Array.isArray(f.value) ? f.value : f.value != null ? [f.value] : [],
-            label: f.label,
+            type: typeName,
+            value: toFieldValueArray(rawVal),
+            label: f.label || f.field_title,
         })
     }
     return out
@@ -85,6 +101,16 @@ export function getRecordFields(record: DRecord): RecordField[] {
         if (d.secret2) fields.push({ type: FieldType.Password, value: [d.secret2] })
         if (d.link) fields.push({ type: FieldType.Url, value: [d.link] })
         if (d.notes) fields.push({ type: FieldType.Note, value: [d.notes] })
+        if (Array.isArray(d.custom)) {
+            for (const c of d.custom) {
+                if (!c) continue
+                fields.push({
+                    type: c.type || FieldType.Text,
+                    value: c.value != null && c.value !== '' ? [c.value] : [],
+                    label: c.name,
+                })
+            }
+        }
         const extraFields = getLegacyExtraFields(record)
         fields.push(...extraFields)
         return fields

--- a/KeeperSdk/src/sharing/Sharing.ts
+++ b/KeeperSdk/src/sharing/Sharing.ts
@@ -5,6 +5,8 @@ import {
     platform,
     getPublicKeysMessage,
     webSafe64FromBytes,
+    recordsShareUpdateMessage,
+    normal64Bytes,
 } from '@keeper-security/keeperapi'
 import { extractErrorMessage, KeeperSdkError } from '../utils/errors'
 
@@ -15,8 +17,6 @@ enum ShareStatus {
     Error = 'error',
     Unknown = 'unknown',
 }
-
-const SHARE_UPDATE_PATH = 'vault/records_share_update'
 
 export type ShareRecordInput = {
     recordUid: string
@@ -44,20 +44,6 @@ export type RemoveShareResult = {
     success: boolean
     status: string
     message: string
-}
-
-function recordsShareUpdateMessage(data: Records.IRecordShareUpdateRequest) {
-    return {
-        path: SHARE_UPDATE_PATH,
-        toBytes(): Uint8Array {
-            return Records.RecordShareUpdateRequest.encode(
-                Records.RecordShareUpdateRequest.create(data)
-            ).finish()
-        },
-        fromBytes(resp: Uint8Array): Records.IRecordShareUpdateResponse {
-            return Records.RecordShareUpdateResponse.decode(resp)
-        },
-    }
 }
 
 type UserKeys = {
@@ -102,13 +88,6 @@ async function loadUserPublicKey(auth: Auth, email: string): Promise<UserKeys> {
     }
 }
 
-function uidToBytes(uid: string): Uint8Array {
-    return platform.base64ToBytes(
-        uid.replace(/-/g, '+').replace(/_/g, '/')
-            + '=='.substring(0, (3 * uid.length) % 4)
-    )
-}
-
 export async function shareRecord(
     auth: Auth,
     recordKey: Uint8Array,
@@ -140,7 +119,7 @@ export async function shareRecord(
 
     const sharedRecord: Records.ISharedRecord = {
         toUsername: email,
-        recordUid: uidToBytes(recordUid),
+        recordUid: normal64Bytes(recordUid),
         recordKey: encryptedRecordKey,
         editable: canEdit,
         shareable: canShare,
@@ -181,7 +160,7 @@ export async function removeRecordShare(
     const msg = recordsShareUpdateMessage({
         removeSharedRecord: [{
             toUsername: email,
-            recordUid: uidToBytes(recordUid),
+            recordUid: normal64Bytes(recordUid),
         }],
     })
 

--- a/KeeperSdk/src/sharing/Sharing.ts
+++ b/KeeperSdk/src/sharing/Sharing.ts
@@ -1,0 +1,208 @@
+import {
+    Auth,
+    Records,
+    Authentication,
+    platform,
+    getPublicKeysMessage,
+    webSafe64FromBytes,
+} from '@keeper-security/keeperapi'
+import { extractErrorMessage, KeeperSdkError } from '../utils/errors'
+
+enum ShareStatus {
+    Success = 'success',
+    PendingAccept = 'pending_accept',
+    MissingPublicKey = 'missing_public_key',
+    Error = 'error',
+    Unknown = 'unknown',
+}
+
+const SHARE_UPDATE_PATH = 'vault/records_share_update'
+
+export type ShareRecordInput = {
+    recordUid: string
+    email: string
+    canEdit?: boolean
+    canShare?: boolean
+}
+
+export type ShareRecordResult = {
+    recordUid: string
+    email: string
+    success: boolean
+    status: string
+    message: string
+}
+
+export type RemoveShareInput = {
+    recordUid: string
+    email: string
+}
+
+export type RemoveShareResult = {
+    recordUid: string
+    email: string
+    success: boolean
+    status: string
+    message: string
+}
+
+function recordsShareUpdateMessage(data: Records.IRecordShareUpdateRequest) {
+    return {
+        path: SHARE_UPDATE_PATH,
+        toBytes(): Uint8Array {
+            return Records.RecordShareUpdateRequest.encode(
+                Records.RecordShareUpdateRequest.create(data)
+            ).finish()
+        },
+        fromBytes(resp: Uint8Array): Records.IRecordShareUpdateResponse {
+            return Records.RecordShareUpdateResponse.decode(resp)
+        },
+    }
+}
+
+type UserKeys = {
+    username: string
+    rsaPublicKey: Uint8Array | null
+    eccPublicKey: Uint8Array | null
+    errorCode: string | null
+}
+
+async function loadUserPublicKey(auth: Auth, email: string): Promise<UserKeys> {
+    const msg = getPublicKeysMessage({ usernames: [email] })
+    let response: Authentication.IGetPublicKeysResponse
+
+    try {
+        response = await auth.executeRest(msg)
+    } catch (err) {
+        throw new KeeperSdkError(`Failed to fetch public key for ${email}: ${extractErrorMessage(err)}`)
+    }
+
+    const keyResponses = response.keyResponses || []
+    if (keyResponses.length === 0) {
+        throw new KeeperSdkError(`No public key returned for ${email}`, 'missing_public_key')
+    }
+
+    const entry = keyResponses[0]
+    if (entry.errorCode) {
+        throw new KeeperSdkError(
+            `Public key lookup failed for ${email}: ${entry.errorCode} - ${entry.message || ''}`,
+            entry.errorCode
+        )
+    }
+
+    return {
+        username: entry.username || email,
+        rsaPublicKey: entry.publicKey && entry.publicKey.length > 0
+            ? entry.publicKey as Uint8Array
+            : null,
+        eccPublicKey: entry.publicEccKey && entry.publicEccKey.length > 0
+            ? entry.publicEccKey as Uint8Array
+            : null,
+        errorCode: entry.errorCode || null,
+    }
+}
+
+function uidToBytes(uid: string): Uint8Array {
+    return platform.base64ToBytes(
+        uid.replace(/-/g, '+').replace(/_/g, '/')
+            + '=='.substring(0, (3 * uid.length) % 4)
+    )
+}
+
+export async function shareRecord(
+    auth: Auth,
+    recordKey: Uint8Array,
+    input: ShareRecordInput
+): Promise<ShareRecordResult> {
+    const { recordUid, email, canEdit = false, canShare = false } = input
+
+    const userKeys = await loadUserPublicKey(auth, email)
+
+    let encryptedRecordKey: Uint8Array
+    let useEccKey = false
+
+    if (userKeys.eccPublicKey) {
+        encryptedRecordKey = await platform.publicEncryptEC(recordKey, userKeys.eccPublicKey)
+        useEccKey = true
+    } else if (userKeys.rsaPublicKey) {
+        const rsaKeyBase64 = platform.bytesToBase64(userKeys.rsaPublicKey)
+        encryptedRecordKey = platform.publicEncrypt(recordKey, rsaKeyBase64)
+        useEccKey = false
+    } else {
+        return {
+            recordUid,
+            email,
+            success: false,
+            status: ShareStatus.MissingPublicKey,
+            message: `No usable public key available for ${email}`,
+        }
+    }
+
+    const sharedRecord: Records.ISharedRecord = {
+        toUsername: email,
+        recordUid: uidToBytes(recordUid),
+        recordKey: encryptedRecordKey,
+        editable: canEdit,
+        shareable: canShare,
+        useEccKey,
+    }
+
+    const msg = recordsShareUpdateMessage({ addSharedRecord: [sharedRecord] })
+
+    let response: Records.IRecordShareUpdateResponse
+    try {
+        response = await auth.executeRest(msg)
+    } catch (err) {
+        return { recordUid, email, success: false, status: ShareStatus.Error, message: extractErrorMessage(err) }
+    }
+
+    const addStatuses = response.addSharedRecordStatus || []
+    if (addStatuses.length > 0) {
+        const st = addStatuses[0]
+        const isSuccess = st.status === ShareStatus.Success || st.status === ShareStatus.PendingAccept
+        return {
+            recordUid,
+            email: st.username || email,
+            success: isSuccess,
+            status: st.status || ShareStatus.Unknown,
+            message: st.message || st.status || '',
+        }
+    }
+
+    return { recordUid, email, success: true, status: ShareStatus.Success, message: 'Record shared successfully' }
+}
+
+export async function removeRecordShare(
+    auth: Auth,
+    input: RemoveShareInput
+): Promise<RemoveShareResult> {
+    const { recordUid, email } = input
+
+    const msg = recordsShareUpdateMessage({
+        removeSharedRecord: [{
+            toUsername: email,
+            recordUid: uidToBytes(recordUid),
+        }],
+    })
+
+    let response: Records.IRecordShareUpdateResponse
+    try {
+        response = await auth.executeRest(msg)
+    } catch (err) {
+        return { recordUid, email, success: false, status: ShareStatus.Error, message: extractErrorMessage(err) }
+    }
+
+    const removeStatuses = response.removeSharedRecordStatus || []
+    if (removeStatuses.length > 0) {
+        const st = removeStatuses[0]
+        return {
+            recordUid,
+            email: st.username || email,
+            success: st.status === ShareStatus.Success,
+            status: st.status || ShareStatus.Unknown,
+            message: st.message || st.status || '',
+        }
+    }
+
+    return { recordUid, email, success: true, status: ShareStatus.Success, message: 'Share removed successfully' }
+}

--- a/KeeperSdk/src/storage/InMemoryStorage.ts
+++ b/KeeperSdk/src/storage/InMemoryStorage.ts
@@ -1,0 +1,156 @@
+import type {
+    VaultStorage,
+    VaultStorageData,
+    VaultStorageKind,
+    VaultStorageResult,
+    Dependency,
+    Dependencies,
+    RemovedDependencies,
+    DRecord,
+} from '@keeper-security/keeperapi'
+
+export class InMemoryStorage implements VaultStorage {
+    private keys = new Map<string, Uint8Array>()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- KeyStorage.saveObject<T> is unconstrained
+    private objects = new Map<string, any>()
+    private store = new Map<string, Map<string, VaultStorageData>>()
+    private deps = new Map<string, Dependency[]>()
+    private arrayCache = new Map<string, VaultStorageData[]>()
+
+    public async getKeyBytes(keyId: string): Promise<Uint8Array | undefined> {
+        return this.keys.get(keyId)
+    }
+
+    public async saveKeyBytes(keyId: string, key: Uint8Array): Promise<void> {
+        this.keys.set(keyId, key)
+    }
+
+    public async getObject<T>(key: string): Promise<T | undefined> {
+        return this.objects.get(key) as T | undefined
+    }
+
+    public async saveObject<T>(key: string, value: T): Promise<void> {
+        this.objects.set(key, value)
+    }
+
+    public async put(item: VaultStorageData): Promise<void> {
+        const kind = item.kind
+        if (!this.store.has(kind)) {
+            this.store.set(kind, new Map())
+        }
+        const uid = this.extractUid(item)
+        this.store.get(kind)!.set(uid, item)
+        this.arrayCache.delete(kind)
+    }
+
+    public async get<T extends VaultStorageKind>(kind: T, uid?: string): Promise<VaultStorageResult<T>> {
+        const kindMap = this.store.get(kind)
+        if (!kindMap) return undefined as VaultStorageResult<T>
+
+        if (uid) {
+            return kindMap.get(uid) as VaultStorageResult<T>
+        }
+        const first = kindMap.values().next()
+        return (first.done ? undefined : first.value) as VaultStorageResult<T>
+    }
+
+    public async delete(kind: VaultStorageKind, uid: string | Uint8Array): Promise<void> {
+        const uidStr = typeof uid === 'string'
+            ? uid
+            : Buffer.from(uid).toString('base64url')
+        this.store.get(kind)?.delete(uidStr)
+        this.arrayCache.delete(kind)
+    }
+
+    public async clear(): Promise<void> {
+        this.store.clear()
+        this.keys.clear()
+        this.objects.clear()
+        this.deps.clear()
+        this.arrayCache.clear()
+    }
+
+    public async getDependencies(uid: string): Promise<Dependency[] | undefined> {
+        return this.deps.get(uid)
+    }
+
+    public async addDependencies(dependencies: Dependencies): Promise<void> {
+        for (const [parentUid, children] of Object.entries(dependencies)) {
+            if (!this.deps.has(parentUid)) {
+                this.deps.set(parentUid, [])
+            }
+            const existing = this.deps.get(parentUid)!
+            const seen = new Set(existing.map(d => d.uid))
+            for (const child of children) {
+                if (!seen.has(child.uid)) {
+                    existing.push(child)
+                    seen.add(child.uid)
+                }
+            }
+        }
+    }
+
+    public async removeDependencies(dependencies: RemovedDependencies): Promise<void> {
+        for (const [parentUid, children] of Object.entries(dependencies)) {
+            if (children === '*') {
+                this.deps.delete(parentUid)
+            } else {
+                const existing = this.deps.get(parentUid)
+                if (existing) {
+                    const removeSet = children as Set<string>
+                    this.deps.set(
+                        parentUid,
+                        existing.filter((d) => !removeSet.has(d.uid))
+                    )
+                }
+            }
+        }
+    }
+
+    public getAll<T extends VaultStorageData>(kind: VaultStorageKind): T[] {
+        const cached = this.arrayCache.get(kind)
+        if (cached) return cached as T[]
+
+        const kindMap = this.store.get(kind)
+        if (!kindMap) return []
+
+        const arr = Array.from(kindMap.values())
+        this.arrayCache.set(kind, arr)
+        return arr as T[]
+    }
+
+    public getRecords(): DRecord[] {
+        return this.getAll<DRecord>('record')
+    }
+
+    public getByUid<T extends VaultStorageData>(kind: VaultStorageKind, uid: string): T | undefined {
+        return this.store.get(kind)?.get(uid) as T | undefined
+    }
+
+    public getCount(kind: VaultStorageKind): number {
+        return this.store.get(kind)?.size ?? 0
+    }
+
+    private extractUid(item: VaultStorageData): string {
+        const record = item as VaultStorageData & {
+            uid?: string
+            token?: string
+            sharedFolderUid?: string
+            recordUid?: string
+            accountUid?: string
+            teamUid?: string
+        }
+        if (record.uid) return record.uid
+        if (record.token) return record.token
+        if (record.sharedFolderUid && record.recordUid) {
+            return `${record.sharedFolderUid}:${record.recordUid}`
+        }
+        if (record.sharedFolderUid && record.accountUid) {
+            return `${record.sharedFolderUid}:${record.accountUid}`
+        }
+        if (record.sharedFolderUid && record.teamUid) {
+            return `${record.sharedFolderUid}:${record.teamUid}`
+        }
+        return '_singleton_'
+    }
+}

--- a/KeeperSdk/src/utils/Logger.ts
+++ b/KeeperSdk/src/utils/Logger.ts
@@ -1,0 +1,71 @@
+export enum LogLevel {
+    DEBUG = 0,
+    INFO = 1,
+    WARN = 2,
+    ERROR = 3,
+    NONE = 4,
+}
+
+export interface ILogger {
+    debug(...args: unknown[]): void
+    info(...args: unknown[]): void
+    warn(...args: unknown[]): void
+    error(...args: unknown[]): void
+}
+
+export class ConsoleLogger implements ILogger {
+    private level: LogLevel
+
+    constructor(level: LogLevel = LogLevel.INFO) {
+        this.level = level
+    }
+
+    public setLevel(level: LogLevel): void {
+        this.level = level
+    }
+
+    public getLevel(): LogLevel {
+        return this.level
+    }
+
+    public debug(...args: unknown[]): void {
+        if (this.level <= LogLevel.DEBUG) console.debug(...args)
+    }
+
+    public info(...args: unknown[]): void {
+        if (this.level <= LogLevel.INFO) console.log(...args)
+    }
+
+    public warn(...args: unknown[]): void {
+        if (this.level <= LogLevel.WARN) console.warn(...args)
+    }
+
+    public error(...args: unknown[]): void {
+        if (this.level <= LogLevel.ERROR) console.error(...args)
+    }
+}
+
+let globalLogger: ILogger = new ConsoleLogger()
+
+export function setLogger(newLogger: ILogger): void {
+    globalLogger = newLogger
+}
+
+export function getLogger(): ILogger {
+    return globalLogger
+}
+
+export function resetLogger(level: LogLevel = LogLevel.INFO): ConsoleLogger {
+    const c = new ConsoleLogger(level)
+    globalLogger = c
+    return c
+}
+
+export const logger: ILogger = {
+    debug: (...args) => globalLogger.debug(...args),
+    info: (...args) => globalLogger.info(...args),
+    warn: (...args) => globalLogger.warn(...args),
+    error: (...args) => globalLogger.error(...args),
+}
+
+export { ConsoleLogger as Logger }

--- a/KeeperSdk/src/utils/constants.ts
+++ b/KeeperSdk/src/utils/constants.ts
@@ -1,0 +1,36 @@
+export const SdkDefaults = {
+    CLIENT_VERSION: 'c17.0.0',
+    DEVICE_NAME: 'JavaScript Keeper SDK',
+    CONFIG_DIR: '.keeper',
+    LOG_FORMAT: '!',
+} as const
+
+export const AuthDefaults = {
+    MAX_LOGIN_ATTEMPTS: 5,
+    APPROVAL_TIMEOUT_MS: 60_000,
+    CODE_VALIDATION_DELAY_MS: 2_000,
+} as const
+
+export const ResultCodes = {
+    INVALID_CREDENTIALS: 'invalid_credentials',
+    MISSING_USERNAME: 'missing_username',
+    MISSING_PASSWORD: 'missing_password',
+    MAX_ATTEMPTS_EXCEEDED: 'max_attempts_exceeded',
+    USER_CANCELLED: 'user_cancelled',
+    NOT_LOGGED_IN: 'not_logged_in',
+    DEVICE_NOT_REGISTERED: 'device_not_registered',
+    NO_PREVIOUS_LOGIN: 'no_previous_login',
+    NO_CLONE_CODE: 'no_clone_code',
+    PERSISTENT_LOGIN_FAILED: 'persistent_login_failed',
+    SESSION_TOKEN_EXPIRED: 'session_token_expired',
+    UNSUPPORTED_2FA_CHANNEL: 'unsupported_2fa_channel',
+} as const
+
+export const KEEPER_PUBLIC_HOSTS: Record<string, string> = {
+    US: 'keepersecurity.com',
+    EU: 'keepersecurity.eu',
+    AU: 'keepersecurity.com.au',
+    CA: 'keepersecurity.ca',
+    JP: 'keepersecurity.jp',
+    GOV: 'govcloud.keepersecurity.us',
+}

--- a/KeeperSdk/src/utils/errors.ts
+++ b/KeeperSdk/src/utils/errors.ts
@@ -1,5 +1,19 @@
 import type { KeeperError } from '@keeper-security/keeperapi'
 
+function parseJsonObjectIfPresent(s: string): Record<string, unknown> | null {
+    const t = s.trim()
+    if (t.length === 0 || (t[0] !== '{' && t[0] !== '[')) return null
+    try {
+        const parsed: unknown = JSON.parse(s)
+        if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
+            return parsed as Record<string, unknown>
+        }
+    } catch {
+        /* not JSON */
+    }
+    return null
+}
+
 export function isKeeperError(err: unknown): err is KeeperError {
     return (
         err != null &&
@@ -22,7 +36,14 @@ export function extractResultCode(err: unknown): string | undefined {
             } catch {}
         }
     }
-    if (typeof err === 'string') return err
+    if (typeof err === 'string') {
+        const parsed = parseJsonObjectIfPresent(err)
+        if (parsed) {
+            if (typeof parsed.result_code === 'string') return parsed.result_code
+            if (typeof parsed.error === 'string') return parsed.error
+        }
+        return err
+    }
     if (typeof err === 'object' && err !== null) {
         const obj = err as Record<string, unknown>
         if (typeof obj.result_code === 'string') return obj.result_code
@@ -35,8 +56,24 @@ export function extractErrorMessage(err: unknown): string {
     if (isKeeperError(err)) {
         return err.message || err.result_code || err.error || 'Unknown Keeper error'
     }
-    if (err instanceof Error) return err.message
-    if (typeof err === 'string') return err
+    if (err instanceof Error) {
+        const parsed = parseJsonObjectIfPresent(err.message)
+        if (parsed) {
+            if (typeof parsed.message === 'string') return parsed.message
+            if (typeof parsed.result_code === 'string') return parsed.result_code
+            if (typeof parsed.error === 'string') return parsed.error
+        }
+        return err.message
+    }
+    if (typeof err === 'string') {
+        const parsed = parseJsonObjectIfPresent(err)
+        if (parsed) {
+            if (typeof parsed.message === 'string') return parsed.message
+            if (typeof parsed.result_code === 'string') return parsed.result_code
+            if (typeof parsed.error === 'string') return parsed.error
+        }
+        return err
+    }
     if (typeof err === 'object' && err !== null) {
         const obj = err as Record<string, unknown>
         if (typeof obj.message === 'string') return obj.message
@@ -66,6 +103,6 @@ export class KeeperSdkError extends Error {
             )
         }
         if (err instanceof Error) return new KeeperSdkError(err.message)
-        return new KeeperSdkError(String(err))
+        return new KeeperSdkError(extractErrorMessage(err))
     }
 }

--- a/KeeperSdk/src/utils/errors.ts
+++ b/KeeperSdk/src/utils/errors.ts
@@ -1,0 +1,71 @@
+import type { KeeperError } from '@keeper-security/keeperapi'
+
+export function isKeeperError(err: unknown): err is KeeperError {
+    return (
+        err != null &&
+        typeof err === 'object' &&
+        !(err instanceof Error) &&
+        ('result_code' in err || 'error' in err || 'response_code' in err)
+    )
+}
+
+export function extractResultCode(err: unknown): string | undefined {
+    if (isKeeperError(err)) {
+        return err.result_code || err.error
+    }
+    if (err instanceof Error) {
+        const msg = err.message
+        if (msg.length > 0 && (msg[0] === '{' || msg[0] === '[')) {
+            try {
+                const parsed = JSON.parse(msg)
+                return parsed.result_code || parsed.error
+            } catch {}
+        }
+    }
+    if (typeof err === 'string') return err
+    if (typeof err === 'object' && err !== null) {
+        const obj = err as Record<string, unknown>
+        if (typeof obj.result_code === 'string') return obj.result_code
+        if (typeof obj.error === 'string') return obj.error
+    }
+    return undefined
+}
+
+export function extractErrorMessage(err: unknown): string {
+    if (isKeeperError(err)) {
+        return err.message || err.result_code || err.error || 'Unknown Keeper error'
+    }
+    if (err instanceof Error) return err.message
+    if (typeof err === 'string') return err
+    if (typeof err === 'object' && err !== null) {
+        const obj = err as Record<string, unknown>
+        if (typeof obj.message === 'string') return obj.message
+        if (typeof obj.result_code === 'string') return obj.result_code
+    }
+    return String(err)
+}
+
+export class KeeperSdkError extends Error {
+    readonly resultCode?: string
+    readonly keeperError?: KeeperError
+
+    constructor(message: string, resultCode?: string, keeperError?: KeeperError) {
+        super(message)
+        this.name = 'KeeperSdkError'
+        this.resultCode = resultCode
+        this.keeperError = keeperError
+    }
+
+    static from(err: unknown): KeeperSdkError {
+        if (err instanceof KeeperSdkError) return err
+        if (isKeeperError(err)) {
+            return new KeeperSdkError(
+                err.message || err.result_code || err.error || 'Unknown Keeper error',
+                err.result_code || err.error,
+                err
+            )
+        }
+        if (err instanceof Error) return new KeeperSdkError(err.message)
+        return new KeeperSdkError(String(err))
+    }
+}

--- a/KeeperSdk/src/utils/index.ts
+++ b/KeeperSdk/src/utils/index.ts
@@ -1,0 +1,4 @@
+export { SdkDefaults, AuthDefaults, ResultCodes, KEEPER_PUBLIC_HOSTS } from './constants'
+export { Logger, ConsoleLogger, LogLevel, logger, setLogger, getLogger, resetLogger } from './Logger'
+export type { ILogger } from './Logger'
+export { KeeperSdkError, isKeeperError, extractErrorMessage, extractResultCode } from './errors'

--- a/KeeperSdk/src/vault/KeeperVault.ts
+++ b/KeeperSdk/src/vault/KeeperVault.ts
@@ -189,6 +189,7 @@ export class KeeperVault {
                 ResultCodes.NO_PREVIOUS_LOGIN
             )
         }
+        this.sessionManager.setLastUsername(username)
 
         const deviceConfig = await this.sessionManager.getDeviceConfig(this.config.host)
         if (!deviceConfig.deviceToken || !deviceConfig.privateKey) {

--- a/KeeperSdk/src/vault/KeeperVault.ts
+++ b/KeeperSdk/src/vault/KeeperVault.ts
@@ -1,0 +1,460 @@
+import {
+    Auth,
+    KeeperEnvironment,
+    syncDown,
+    DRecord,
+    DRecordMetadata,
+    DSharedFolder,
+    DTeam,
+    DUserFolder,
+    Authentication,
+} from '@keeper-security/keeperapi'
+import type { SyncResult, SyncLogFormat, VaultStorage, SessionStorage, AuthUI3 } from '@keeper-security/keeperapi'
+import { InMemoryStorage } from '../storage/InMemoryStorage'
+import { SessionManager } from '../auth/SessionManager'
+import { ConsoleAuthUI } from '../auth/ConsoleAuthUI'
+import { searchRecords, formatRecord, getRecordTitle, getRecordType } from '../records/RecordUtils'
+import {
+    addRecord as addRecordOp,
+    updateRecord as updateRecordOp,
+    deleteRecord as deleteRecordOp,
+    getRecordHistory as getRecordHistoryOp,
+    moveRecord as moveRecordOp,
+} from '../records/RecordOperations'
+import type {
+    NewRecordInput,
+    TypedRecordData,
+    AddRecordResult,
+    UpdateRecordResult,
+    DeleteRecordResult,
+    RecordHistoryResult,
+    MoveRecordInput,
+    MoveRecordResult,
+} from '../records/RecordOperations'
+import {
+    shareRecord as shareRecordOp,
+    removeRecordShare as removeRecordShareOp,
+} from '../sharing/Sharing'
+import type {
+    ShareRecordInput,
+    ShareRecordResult,
+    RemoveShareInput,
+    RemoveShareResult,
+} from '../sharing/Sharing'
+import { ConsoleLogger, LogLevel, KeeperSdkError, extractErrorMessage, SdkDefaults, ResultCodes } from '../utils'
+import type { ILogger } from '../utils'
+
+enum VaultStatus {
+    RecordNotFound = 'RECORD_NOT_FOUND',
+    RecordKeyNotFound = 'RECORD_KEY_NOT_FOUND',
+}
+
+export type KeeperVaultConfig = {
+    host?: string
+    clientVersion?: string
+    configDir?: string
+    useConsoleAuth?: boolean
+    logFormat?: SyncLogFormat
+    logLevel?: LogLevel
+    autoSync?: boolean
+    storage?: InMemoryStorage
+    sessionStorage?: SessionManager
+    authUI?: AuthUI3
+}
+
+export type VaultSummary = {
+    recordCount: number
+    sharedFolderCount: number
+    teamCount: number
+    folderCount: number
+}
+
+export class KeeperVault {
+    private auth: Auth | null = null
+    private readonly storage: InMemoryStorage
+    private readonly sessionManager: SessionManager
+    private readonly authUI: AuthUI3
+    private readonly config: Required<Omit<KeeperVaultConfig, 'storage' | 'sessionStorage' | 'authUI'>>
+    private readonly log: ILogger
+    private synced = false
+    private batchDepth = 0
+
+    constructor(config?: KeeperVaultConfig) {
+        this.config = {
+            host: config?.host || KeeperEnvironment.Prod,
+            clientVersion: config?.clientVersion || SdkDefaults.CLIENT_VERSION,
+            configDir: config?.configDir ?? '',
+            useConsoleAuth: config?.useConsoleAuth !== false,
+            logFormat: config?.logFormat || SdkDefaults.LOG_FORMAT,
+            logLevel: config?.logLevel ?? LogLevel.INFO,
+            autoSync: config?.autoSync !== false,
+        }
+
+        this.log = new ConsoleLogger(this.config.logLevel)
+        this.storage = config?.storage || new InMemoryStorage()
+        this.sessionManager = config?.sessionStorage || new SessionManager(this.config.configDir || undefined)
+        this.authUI = config?.authUI || new ConsoleAuthUI()
+    }
+
+    private async createAuth(options?: { useSessionResumption?: boolean }): Promise<Auth> {
+        const host = this.config.host
+        const baseDeviceConfig = await this.sessionManager.getDeviceConfig(host)
+        const deviceConfig = {
+            ...baseDeviceConfig,
+            deviceName: baseDeviceConfig.deviceName || SdkDefaults.DEVICE_NAME,
+        }
+
+        const sessionStorage: SessionStorage = options?.useSessionResumption === false
+            ? {
+                getCloneCode: async () => null,
+                saveCloneCode: (h, u, c) => this.sessionManager.saveCloneCode(h, u, c),
+                getSessionParameters: () => this.sessionManager.getSessionParameters(),
+                saveSessionParameters: (p) => this.sessionManager.saveSessionParameters(p),
+            }
+            : this.sessionManager
+
+        return new Auth({
+            host,
+            clientVersion: this.config.clientVersion,
+            deviceConfig,
+            authUI3: this.config.useConsoleAuth ? this.authUI : undefined,
+            sessionStorage,
+            onDeviceConfig: this.sessionManager.createOnDeviceConfig(host),
+            useSessionResumption: options?.useSessionResumption,
+        })
+    }
+
+    private getAuthOrThrow(): Auth {
+        if (!this.auth || !this.auth.sessionToken) {
+            throw new KeeperSdkError('Not logged in. Call login() first.', ResultCodes.NOT_LOGGED_IN)
+        }
+        return this.auth
+    }
+
+    public async login(username: string, password: string): Promise<void> {
+        this.auth = await this.createAuth({ useSessionResumption: false })
+        this.sessionManager.setLastUsername(username)
+
+        await this.auth.loginV3({
+            username,
+            password,
+            loginType: Authentication.LoginType.NORMAL,
+            loginMethod: Authentication.LoginMethod.EXISTING_ACCOUNT,
+        })
+
+        this.synced = false
+        this.log.info(`Logged in as ${username}`)
+    }
+
+    public async loginWithSessionToken(username: string, sessionToken: string): Promise<void> {
+        const deviceConfig = await this.sessionManager.getDeviceConfig(this.config.host)
+
+        if (!deviceConfig.deviceToken || !deviceConfig.privateKey) {
+            throw new KeeperSdkError(
+                'Device is not registered for this host. Perform a normal login first to register the device before using session token login.',
+                ResultCodes.DEVICE_NOT_REGISTERED
+            )
+        }
+
+        this.auth = await this.createAuth()
+        this.sessionManager.setLastUsername(username)
+
+        await this.auth.loginV3({
+            username,
+            givenSessionToken: sessionToken,
+            loginType: Authentication.LoginType.NORMAL,
+            loginMethod: Authentication.LoginMethod.EXISTING_ACCOUNT,
+        })
+
+        if (!this.auth.sessionToken) {
+            throw new KeeperSdkError(
+                'Session token login failed — token may be expired or invalid.',
+                ResultCodes.SESSION_TOKEN_EXPIRED
+            )
+        }
+
+        this.synced = false
+        this.log.info(`Logged in as ${username} (via session token)`)
+    }
+
+    public getSessionToken(): string | undefined {
+        return this.auth?.sessionToken || undefined
+    }
+
+    public async resumeSession(): Promise<void> {
+        const username = await this.sessionManager.getLastUsername()
+        if (!username) {
+            throw new KeeperSdkError(
+                'No previous login found. Perform a normal login first.',
+                ResultCodes.NO_PREVIOUS_LOGIN
+            )
+        }
+
+        const deviceConfig = await this.sessionManager.getDeviceConfig(this.config.host)
+        if (!deviceConfig.deviceToken || !deviceConfig.privateKey) {
+            throw new KeeperSdkError(
+                'Device is not registered for this host. Perform a normal login first.',
+                ResultCodes.DEVICE_NOT_REGISTERED
+            )
+        }
+
+        const cloneCode = await this.sessionManager.getCloneCode(this.config.host, username)
+        if (!cloneCode) {
+            throw new KeeperSdkError(
+                'No clone code found. Persistent login not enabled or clone code expired. Perform a normal login.',
+                ResultCodes.NO_CLONE_CODE
+            )
+        }
+
+        this.auth = await this.createAuth({ useSessionResumption: true })
+
+        await this.auth.loginV3({
+            loginType: Authentication.LoginType.NORMAL,
+            resumeSessionOnly: true,
+        })
+
+        if (!this.auth.sessionToken) {
+            throw new KeeperSdkError(
+                'Persistent login failed — clone code may be expired or persistent login not enabled. Perform a normal login.',
+                ResultCodes.PERSISTENT_LOGIN_FAILED
+            )
+        }
+
+        this.synced = false
+        this.log.info(`Session resumed for ${username} (persistent login)`)
+    }
+
+    public async sync(): Promise<SyncResult> {
+        const auth = this.getAuthOrThrow()
+
+        const result = await syncDown({
+            auth,
+            storage: this.storage,
+            logFormat: this.config.logFormat,
+        })
+
+        this.synced = true
+        return result
+    }
+
+    public async batch(fn: () => Promise<void>): Promise<void> {
+        this.batchDepth++
+        try {
+            await fn()
+        } finally {
+            this.batchDepth--
+            if (this.batchDepth === 0 && this.config.autoSync) {
+                await this.sync()
+            }
+        }
+    }
+
+    private async syncIfNeeded(): Promise<void> {
+        if (this.batchDepth > 0) {
+            this.synced = false
+            return
+        }
+        if (this.config.autoSync) {
+            await this.sync()
+        } else {
+            this.synced = false
+        }
+    }
+
+    public getRecords(): DRecord[] {
+        return this.storage.getRecords()
+    }
+
+    public getRecordByUid(uid: string): DRecord | undefined {
+        return this.storage.getByUid<DRecord>('record', uid)
+    }
+
+    public findRecord(uidOrTitle: string): DRecord | undefined {
+        const byUid = this.getRecordByUid(uidOrTitle)
+        if (byUid) return byUid
+
+        const needle = uidOrTitle.toLowerCase()
+        return this.getRecords().find((r) => getRecordTitle(r).toLowerCase() === needle)
+    }
+
+    public findRecords(criteria: string): DRecord[] {
+        return searchRecords(this.getRecords(), criteria)
+    }
+
+    public getRecordsByVersion(version: number): DRecord[] {
+        return this.getRecords().filter((r) => r.version === version)
+    }
+
+    public getRecordsByType(recordType: string): DRecord[] {
+        return this.getRecords().filter((r) => getRecordType(r) === recordType)
+    }
+
+    public getRecordMetadata(): DRecordMetadata[] {
+        return this.storage.getAll<DRecordMetadata>('metadata')
+    }
+
+    public getRecordMetadataByUid(uid: string): DRecordMetadata | undefined {
+        return this.storage.getByUid<DRecordMetadata>('metadata', uid)
+    }
+
+    public getSharedFolders(): DSharedFolder[] {
+        return this.storage.getAll<DSharedFolder>('shared_folder')
+    }
+
+    public getTeams(): DTeam[] {
+        return this.storage.getAll<DTeam>('team')
+    }
+
+    public getUserFolders(): DUserFolder[] {
+        return this.storage.getAll<DUserFolder>('user_folder')
+    }
+
+    public getSummary(): VaultSummary {
+        return {
+            recordCount: this.storage.getCount('record'),
+            sharedFolderCount: this.storage.getCount('shared_folder'),
+            teamCount: this.storage.getCount('team'),
+            folderCount: this.storage.getCount('user_folder'),
+        }
+    }
+
+    public printRecords(showDetails = false): void {
+        const records = this.getRecords()
+        if (records.length === 0) {
+            this.log.info('No records found in vault.')
+            return
+        }
+        this.log.info(`\n=== Vault Records (${records.length}) ===\n`)
+        for (const record of records) {
+            this.log.info(formatRecord(record, showDetails))
+        }
+    }
+
+    public async addRecord(input: NewRecordInput): Promise<AddRecordResult> {
+        const auth = this.getAuthOrThrow()
+        const result = await addRecordOp(auth, input)
+        if (result.success) await this.syncIfNeeded()
+        return result
+    }
+
+    public async updateRecord(recordUid: string, data: TypedRecordData): Promise<UpdateRecordResult> {
+        const auth = this.getAuthOrThrow()
+
+        const record = this.getRecordByUid(recordUid)
+        if (!record) {
+            return { recordUid, success: false, status: VaultStatus.RecordNotFound }
+        }
+
+        const keyBytes = await this.storage.getKeyBytes(recordUid)
+        if (!keyBytes) {
+            return { recordUid, success: false, status: VaultStatus.RecordKeyNotFound }
+        }
+
+        const result = await updateRecordOp(auth, recordUid, data, record.revision, keyBytes)
+        if (result.success) await this.syncIfNeeded()
+        return result
+    }
+
+    public async deleteRecord(recordUid: string): Promise<DeleteRecordResult> {
+        const auth = this.getAuthOrThrow()
+        const result = await deleteRecordOp(auth, recordUid)
+        if (result.success) await this.syncIfNeeded()
+        return result
+    }
+
+    public async moveRecord(input: MoveRecordInput): Promise<MoveRecordResult> {
+        const auth = this.getAuthOrThrow()
+        const result = await moveRecordOp(auth, this.storage, input)
+        if (result.success) await this.syncIfNeeded()
+        return result
+    }
+
+    public async shareRecord(input: ShareRecordInput): Promise<ShareRecordResult> {
+        const auth = this.getAuthOrThrow()
+
+        const record = this.getRecordByUid(input.recordUid)
+            || this.findRecord(input.recordUid)
+        if (!record) {
+            return {
+                recordUid: input.recordUid,
+                email: input.email,
+                success: false,
+                status: VaultStatus.RecordNotFound,
+                message: `Record "${input.recordUid}" not found`,
+            }
+        }
+
+        const keyBytes = await this.storage.getKeyBytes(record.uid)
+        if (!keyBytes) {
+            return {
+                recordUid: record.uid,
+                email: input.email,
+                success: false,
+                status: VaultStatus.RecordKeyNotFound,
+                message: 'Record key not available',
+            }
+        }
+
+        const result = await shareRecordOp(auth, keyBytes, { ...input, recordUid: record.uid })
+        if (result.success) await this.syncIfNeeded()
+        return result
+    }
+
+    public async removeRecordShare(input: RemoveShareInput): Promise<RemoveShareResult> {
+        const auth = this.getAuthOrThrow()
+        const result = await removeRecordShareOp(auth, input)
+        if (result.success) await this.syncIfNeeded()
+        return result
+    }
+
+    public async getRecordHistory(recordUid: string): Promise<RecordHistoryResult> {
+        const auth = this.getAuthOrThrow()
+
+        const keyBytes = await this.storage.getKeyBytes(recordUid)
+        if (!keyBytes) {
+            return { recordUid, history: [] }
+        }
+
+        return getRecordHistoryOp(auth, recordUid, keyBytes)
+    }
+
+    public getStorage(): VaultStorage {
+        return this.storage
+    }
+
+    public getAuth(): Auth {
+        return this.getAuthOrThrow()
+    }
+
+    public disconnect(): void {
+        if (this.auth) {
+            try { this.auth.disconnect() } catch (err) {
+                this.log.debug('disconnect error:', extractErrorMessage(err))
+            }
+            this.auth = null
+        }
+        this.synced = false
+    }
+
+    public async logout(): Promise<void> {
+        if (this.auth) {
+            try { await this.auth.logout() } catch (err) {
+                this.log.debug('logout error:', extractErrorMessage(err))
+            }
+        }
+        this.disconnect()
+        this.log.info('Logged out.')
+    }
+
+    public get host(): string {
+        return this.config.host
+    }
+
+    public get isLoggedIn(): boolean {
+        return this.auth !== null && !!this.auth.sessionToken
+    }
+
+    public get isSynced(): boolean {
+        return this.synced
+    }
+}

--- a/KeeperSdk/tsconfig.json
+++ b/KeeperSdk/tsconfig.json
@@ -1,0 +1,14 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es2018",
+        "sourceMap": true,
+        "strict": false,
+        "skipLibCheck": true,
+        "esModuleInterop": true,
+        "declaration": true,
+        "outDir": "dist"
+    },
+    "include": ["src"],
+    "exclude": ["node_modules", "dist"]
+}

--- a/examples/sdk_example/README.md
+++ b/examples/sdk_example/README.md
@@ -1,0 +1,65 @@
+# Keeper SDK Examples
+
+Interactive examples demonstrating the Keeper JavaScript SDK.
+
+## Prerequisites
+
+- Node.js 16+
+- A Keeper account with credentials
+
+## Setup
+
+```bash
+# From the repository root
+cd examples/sdk_example
+
+# Install dependencies
+npm install
+
+# Link the local SDK (if developing against the local KeeperSdk)
+npm run link-local
+```
+
+## Configuration
+
+Examples use `~/.keeper/config.json` for saved credentials and persistent login. If the file is not found, you will be prompted for server, username, and password.
+
+## Available Examples
+
+### Authentication
+
+| Command | Description |
+|---|---|
+| `npm run auth:login` | Master password login with retry logic, masked input, and vault sync. Automatically attempts persistent login (via clone code from `~/.keeper/config.json`) before falling back to the password prompt. |
+| `npm run auth:session-token` | Login using an existing session token for pre-authenticated workflows. Prompts for username, host, and session token. |
+
+### Records
+
+| Command | Description |
+|---|---|
+| `npm run records:list` | List all records in the vault |
+| `npm run records:get` | Get details of a specific record by UID or title |
+| `npm run records:add` | Add a new typed record to the vault |
+| `npm run records:update` | Update fields on an existing record |
+| `npm run records:delete` | Delete a record (with confirmation prompt) |
+| `npm run records:history` | View revision history for a record |
+| `npm run records:find-password` | Find a record's password and copy it to clipboard |
+| `npm run records:move` | Move a record to a different folder |
+
+### Sharing
+
+| Command | Description |
+|---|---|
+| `npm run sharing:share-record` | Share a record with another Keeper user |
+
+## Usage
+
+Run any example with `npm run <script>`:
+
+```bash
+npm run auth:login
+npm run records:list
+npm run records:get
+```
+
+Most examples will log in automatically using persistent login (if configured) or prompt for credentials. After authentication, follow the interactive prompts.

--- a/examples/sdk_example/README.md
+++ b/examples/sdk_example/README.md
@@ -4,7 +4,7 @@ Interactive examples demonstrating the Keeper JavaScript SDK.
 
 ## Prerequisites
 
-- Node.js 16+
+- Node.js 20 LTS or newer (aligned with `@types/node` in this repo)
 - A Keeper account with credentials
 
 ## Setup

--- a/examples/sdk_example/package.json
+++ b/examples/sdk_example/package.json
@@ -1,0 +1,28 @@
+{
+    "name": "sdk-example",
+    "version": "1.0.0",
+    "description": "Example usage of the KeeperSdk wrapper — mirrors Python SDK examples",
+    "scripts": {
+        "auth:login": "ts-node src/auth/login.ts",
+        "auth:session-token": "ts-node src/auth/session_token_login.ts",
+        "records:list": "ts-node src/records/list_records.ts",
+        "records:get": "ts-node src/records/get_record.ts",
+        "records:add": "ts-node src/records/add_record.ts",
+        "records:update": "ts-node src/records/update_record.ts",
+        "records:delete": "ts-node src/records/delete_record.ts",
+        "records:history": "ts-node src/records/record_history.ts",
+        "records:find-password": "ts-node src/records/find_password.ts",
+        "records:move": "ts-node src/records/move_record.ts",
+        "sharing:share-record": "ts-node src/sharing/share_record.ts",
+        "link-local": "cd ../../KeeperSdk && npm link ../keeperapi && cd ../examples/sdk_example && npm link ../../keeperapi",
+        "types": "tsc --watch",
+        "types:ci": "tsc"
+    },
+    "dependencies": {
+        "@keeper-security/keeperapi": "17.1.0",
+        "@types/node": "^20.9.1",
+        "ts-node": "^10.7.0",
+        "tsconfig-paths": "^4.2.0",
+        "typescript": "^4.6.3"
+    }
+}

--- a/examples/sdk_example/src/auth/login.ts
+++ b/examples/sdk_example/src/auth/login.ts
@@ -1,0 +1,87 @@
+import {
+    KeeperVault,
+    KeeperSdkError,
+    loadKeeperConfig,
+    resolveServer,
+    prompt,
+    suppressLogs,
+    cleanup,
+    logger,
+    extractResultCode,
+    SdkDefaults,
+    ResultCodes,
+} from 'keeper-sdk'
+import { runExample } from '../utils/runner'
+
+const MAX_ATTEMPTS = 5
+
+async function passwordLogin() {
+    const config = await loadKeeperConfig()
+    const defaultUsername = config.last_login || config.user || ''
+
+    let username: string
+    if (defaultUsername) {
+        logger.info(`Enter master password for ${defaultUsername}`)
+        username = defaultUsername
+    } else {
+        username = await prompt('Username (email): ')
+        if (!username) throw new KeeperSdkError('Username is required.', ResultCodes.MISSING_USERNAME)
+    }
+
+    const host = await resolveServer(username)
+    const vault = new KeeperVault({ host, clientVersion: SdkDefaults.CLIENT_VERSION })
+
+    try {
+        for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+            const password = await prompt('Password: ', true)
+            if (!password) throw new KeeperSdkError('Password is required.', ResultCodes.MISSING_PASSWORD)
+
+            const restore = suppressLogs()
+            try {
+                await vault.login(username, password)
+                restore()
+                break
+            } catch (err) {
+                restore()
+                const resultCode = extractResultCode(err)
+                if (resultCode === ResultCodes.INVALID_CREDENTIALS) {
+                    const remaining = MAX_ATTEMPTS - attempt
+                    if (remaining > 0) {
+                        logger.warn(`Incorrect Password (${remaining} attempt${remaining === 1 ? '' : 's'} remaining)`)
+                        continue
+                    }
+                    throw new KeeperSdkError(`Maximum login attempts (${MAX_ATTEMPTS}) exceeded.`, ResultCodes.MAX_ATTEMPTS_EXCEEDED)
+                }
+                throw KeeperSdkError.from(err)
+            }
+        }
+
+        logger.info('Successfully authenticated with Master Password\n')
+        logger.info('Syncing vault...')
+        const restore = suppressLogs()
+        try {
+            await vault.sync()
+        } finally {
+            restore()
+        }
+
+        const auth = vault.getAuth()
+        const summary = vault.getSummary()
+
+        logger.info('--- Session Info ---')
+        logger.info(`  Username:       ${auth.username}`)
+        logger.info(`  Server:         ${vault.host}`)
+        logger.info(`  Session Token:  ${auth.sessionToken || '(none)'}`)
+        logger.info(`  Data Key:       ${auth.dataKey ? '(loaded)' : '(not loaded)'}`)
+        logger.info(`  Records:        ${summary.recordCount}`)
+        logger.info(`  Shared Folders: ${summary.sharedFolderCount}`)
+        logger.info(`  Teams:          ${summary.teamCount}`)
+        logger.info(`  Folders:        ${summary.folderCount}`)
+
+        logger.info('\nLogin successful. Session is active.')
+    } finally {
+        cleanup(vault)
+    }
+}
+
+runExample(passwordLogin)

--- a/examples/sdk_example/src/auth/login.ts
+++ b/examples/sdk_example/src/auth/login.ts
@@ -10,7 +10,7 @@ import {
     extractResultCode,
     SdkDefaults,
     ResultCodes,
-} from 'keeper-sdk'
+} from '@keeper-security/keeper-sdk-javascript'
 import { runExample } from '../utils/runner'
 
 const MAX_ATTEMPTS = 5

--- a/examples/sdk_example/src/auth/session_token_login.ts
+++ b/examples/sdk_example/src/auth/session_token_login.ts
@@ -1,4 +1,4 @@
-import { KeeperVault, prompt, suppressLogs, cleanup, logger, KeeperSdkError, SdkDefaults, ResultCodes } from 'keeper-sdk'
+import { KeeperVault, prompt, suppressLogs, cleanup, logger, KeeperSdkError, SdkDefaults, ResultCodes } from '@keeper-security/keeper-sdk-javascript'
 import { runExample } from '../utils/runner'
 
 async function main() {

--- a/examples/sdk_example/src/auth/session_token_login.ts
+++ b/examples/sdk_example/src/auth/session_token_login.ts
@@ -1,0 +1,58 @@
+import { KeeperVault, prompt, suppressLogs, cleanup, logger, KeeperSdkError, SdkDefaults, ResultCodes } from 'keeper-sdk'
+import { runExample } from '../utils/runner'
+
+async function main() {
+    const username = await prompt('Username (email): ')
+    if (!username) throw new KeeperSdkError('Username is required.', ResultCodes.MISSING_USERNAME)
+
+    const host = await prompt('Host [keepersecurity.com]: ')
+
+    const sessionToken = await prompt('Session Token: ')
+    if (!sessionToken) throw new KeeperSdkError('Session token is required.', 'missing_session_token')
+
+    const resolvedHost = host || 'keepersecurity.com'
+
+    logger.info(`\nLogging in as ${username} on ${resolvedHost} using session token...`)
+
+    const vault = new KeeperVault({ host: resolvedHost, clientVersion: SdkDefaults.CLIENT_VERSION })
+
+    try {
+        {
+            const restore = suppressLogs()
+            try {
+                await vault.loginWithSessionToken(username, sessionToken)
+            } finally {
+                restore()
+            }
+        }
+
+        const auth = vault.getAuth()
+
+        logger.info('--- Session Info ---')
+        logger.info(`  Username:       ${auth.username}`)
+        logger.info(`  Session Token:  ${auth.sessionToken ? '(active)' : '(none)'}`)
+        logger.info(`  Data Key:       ${auth.dataKey ? '(loaded)' : '(not loaded)'}`)
+
+        logger.info('\nSyncing vault...')
+        {
+            const restore = suppressLogs()
+            try {
+                await vault.sync()
+            } finally {
+                restore()
+            }
+        }
+
+        const summary = vault.getSummary()
+        logger.info(`  Records:        ${summary.recordCount}`)
+        logger.info(`  Shared Folders: ${summary.sharedFolderCount}`)
+        logger.info(`  Teams:          ${summary.teamCount}`)
+        logger.info(`  Folders:        ${summary.folderCount}`)
+
+        logger.info('\nLogin successful. Session is active.')
+    } finally {
+        cleanup(vault)
+    }
+}
+
+runExample(main)

--- a/examples/sdk_example/src/records/add_record.ts
+++ b/examples/sdk_example/src/records/add_record.ts
@@ -1,4 +1,4 @@
-import { login, cleanup, suppressLogs, formatRecord, getRecordTitle, logger } from 'keeper-sdk'
+import { login, cleanup, suppressLogs, formatRecord, getRecordTitle, logger } from '@keeper-security/keeper-sdk-javascript'
 import { runExample } from '../utils/runner'
 
 async function addRecord() {

--- a/examples/sdk_example/src/records/add_record.ts
+++ b/examples/sdk_example/src/records/add_record.ts
@@ -1,0 +1,58 @@
+import { login, cleanup, suppressLogs, formatRecord, getRecordTitle, logger } from 'keeper-sdk'
+import { runExample } from '../utils/runner'
+
+async function addRecord() {
+    const vault = await login()
+
+    try {
+        logger.info('Adding new record to vault...')
+        logger.info('-'.repeat(50))
+
+        let result
+        {
+            const restore = suppressLogs()
+            try {
+                result = await vault.addRecord({
+                    version: 3,
+                    data: {
+                        type: 'login',
+                        title: 'Example SDK Record',
+                        fields: [
+                            { type: 'login', value: ['userSDK@example.com'] },
+                            { type: 'password', value: ['SecureSDKPassword123!'] },
+                            { type: 'url', value: ['https://SDKexample.com'] },
+                        ],
+                        notes: 'This is an example record created using the Keeper SDK',
+                    },
+                })
+            } finally {
+                restore()
+            }
+        }
+
+        if (result.success) {
+            logger.info('Successfully added record!')
+            logger.info(`Record UID: ${result.recordUid}`)
+
+            logger.info('\nVerifying record was added...')
+            const restore = suppressLogs()
+            try {
+                await vault.sync()
+            } finally {
+                restore()
+            }
+
+            const record = vault.getRecordByUid(result.recordUid)
+            if (record) {
+                logger.info(`Verified: "${getRecordTitle(record)}" found in vault.`)
+                logger.info(formatRecord(record, true))
+            }
+        } else {
+            logger.error(`Error adding record: ${result.status}`)
+        }
+    } finally {
+        cleanup(vault)
+    }
+}
+
+runExample(addRecord)

--- a/examples/sdk_example/src/records/delete_record.ts
+++ b/examples/sdk_example/src/records/delete_record.ts
@@ -1,4 +1,4 @@
-import { login, cleanup, prompt, suppressLogs, getRecordTitle, logger } from 'keeper-sdk'
+import { login, cleanup, prompt, suppressLogs, getRecordTitle, logger } from '@keeper-security/keeper-sdk-javascript'
 import { runExample } from '../utils/runner'
 
 async function deleteRecord() {

--- a/examples/sdk_example/src/records/delete_record.ts
+++ b/examples/sdk_example/src/records/delete_record.ts
@@ -1,0 +1,49 @@
+import { login, cleanup, prompt, suppressLogs, getRecordTitle, logger } from 'keeper-sdk'
+import { runExample } from '../utils/runner'
+
+async function deleteRecord() {
+    const vault = await login()
+
+    try {
+        const uid = await prompt('Enter Record UID or title to delete: ')
+        if (!uid) {
+            logger.info('No input provided.')
+            return
+        }
+
+        const record = vault.findRecord(uid)
+        if (!record) {
+            logger.info(`Record "${uid}" not found.`)
+            return
+        }
+
+        const title = getRecordTitle(record)
+        const answer = await prompt(`\nAre you sure you want to delete "${title}" (${record.uid})? [y/N]: `)
+
+        if (answer.toLowerCase() !== 'y') {
+            logger.info('Delete cancelled.')
+            return
+        }
+
+        logger.info('Deleting record...')
+        let result
+        {
+            const restore = suppressLogs()
+            try {
+                result = await vault.deleteRecord(record.uid)
+            } finally {
+                restore()
+            }
+        }
+
+        if (result.success) {
+            logger.info(`Record "${title}" deleted successfully.`)
+        } else {
+            logger.error(`Failed to delete record: ${result.message || 'Unknown error'}`)
+        }
+    } finally {
+        cleanup(vault)
+    }
+}
+
+runExample(deleteRecord)

--- a/examples/sdk_example/src/records/find_password.ts
+++ b/examples/sdk_example/src/records/find_password.ts
@@ -1,0 +1,57 @@
+import { execFileSync } from 'child_process'
+import { login, cleanup, prompt, getRecordTitle, getRecordPassword, logger, extractErrorMessage } from 'keeper-sdk'
+import { runExample } from '../utils/runner'
+
+const CLIPBOARD_TIMEOUT_MS = 3000
+
+function copyToClipboard(text: string): boolean {
+    const opts = { input: text, timeout: CLIPBOARD_TIMEOUT_MS }
+    try {
+        if (process.platform === 'darwin') {
+            execFileSync('pbcopy', [], opts)
+        } else if (process.platform === 'win32') {
+            execFileSync('clip', [], opts)
+        } else {
+            execFileSync('xclip', ['-selection', 'clipboard'], opts)
+        }
+        return true
+    } catch (err) {
+        logger.debug('Clipboard copy failed:', extractErrorMessage(err))
+        return false
+    }
+}
+
+async function findPassword() {
+    const vault = await login()
+
+    try {
+        const input = await prompt('Enter Record UID or title: ')
+        if (!input) {
+            logger.info('No input provided.')
+            return
+        }
+
+        const record = vault.findRecord(input)
+        if (!record) {
+            logger.info(`Record "${input}" not found.`)
+            return
+        }
+
+        const password = getRecordPassword(record)
+        if (!password) {
+            logger.info('No password found for this record.')
+            return
+        }
+
+        const title = getRecordTitle(record)
+        if (copyToClipboard(password)) {
+            logger.info(`Password for "${title}" copied to clipboard.`)
+        } else {
+            logger.error('Failed to copy to clipboard.')
+        }
+    } finally {
+        cleanup(vault)
+    }
+}
+
+runExample(findPassword)

--- a/examples/sdk_example/src/records/find_password.ts
+++ b/examples/sdk_example/src/records/find_password.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from 'child_process'
-import { login, cleanup, prompt, getRecordTitle, getRecordPassword, logger, extractErrorMessage } from 'keeper-sdk'
+import { login, cleanup, prompt, getRecordTitle, getRecordPassword, logger, extractErrorMessage } from '@keeper-security/keeper-sdk-javascript'
 import { runExample } from '../utils/runner'
 
 const CLIPBOARD_TIMEOUT_MS = 3000

--- a/examples/sdk_example/src/records/get_record.ts
+++ b/examples/sdk_example/src/records/get_record.ts
@@ -1,0 +1,118 @@
+import {
+    login,
+    cleanup,
+    prompt,
+    getRecordTitle,
+    getRecordType,
+    getRecordFields,
+    getRecordLogin,
+    getRecordPassword,
+    getRecordUrl,
+    logger,
+} from 'keeper-sdk'
+import { runExample } from '../utils/runner'
+import { formatFieldValue, LEGACY_RECORD_MAX_VERSION } from '../utils/format'
+
+async function getRecord() {
+    const vault = await login()
+
+    try {
+        const records = vault.getRecords()
+
+        if (records.length === 0) {
+            logger.info('No records found in vault.')
+            return
+        }
+
+        const searchInput = await prompt('Enter record UID or title: ')
+
+        if (!searchInput) {
+            logger.info('No input provided. Exiting.')
+            return
+        }
+
+        const record = vault.findRecord(searchInput)
+
+        if (!record) {
+            logger.info(`\nRecord "${searchInput}" not found.`)
+            return
+        }
+
+        const title = getRecordTitle(record)
+        const type = getRecordType(record)
+        const version = record.version
+
+        logger.info('\n' + '-'.repeat(50))
+        logger.info('Record Details')
+        logger.info('-'.repeat(50))
+        logger.info(`  Title:      ${title}`)
+        logger.info(`  Record UID: ${record.uid}`)
+        logger.info(`  Version:    ${version}`)
+        logger.info(`  Revision:   ${record.revision}`)
+        logger.info(`  Shared:     ${record.shared}`)
+
+        if (version <= LEGACY_RECORD_MAX_VERSION) {
+            displayLegacyRecord(record)
+        } else {
+            displayTypedRecord(record, type)
+        }
+
+        displayMetadata(vault, record.uid)
+        logger.info('-'.repeat(50))
+    } finally {
+        cleanup(vault)
+    }
+}
+
+function displayLegacyRecord(record: { data?: Record<string, unknown> }): void {
+    const version = (record as { version: number }).version
+    logger.info(`  Type:       password (legacy v${version})`)
+    const loginVal = getRecordLogin(record as Parameters<typeof getRecordLogin>[0])
+    const password = getRecordPassword(record as Parameters<typeof getRecordPassword>[0])
+    const url = getRecordUrl(record as Parameters<typeof getRecordUrl>[0])
+
+    if (loginVal) logger.info(`  Login:      ${loginVal}`)
+    if (password) logger.info(`  Password:   ${'*'.repeat(password.length)}`)
+    if (url) logger.info(`  URL:        ${url}`)
+
+    const data = record.data as Record<string, unknown> | undefined
+    if (data?.notes) logger.info(`  Notes:      ${data.notes}`)
+
+    if (data?.custom && Array.isArray(data.custom)) {
+        logger.info('\n  Custom Fields:')
+        for (const cf of data.custom) {
+            const entry = cf as { name?: string; type?: string; value?: string }
+            logger.info(`    ${entry.name || entry.type || 'custom'}: ${entry.value}`)
+        }
+    }
+}
+
+function displayTypedRecord(record: Parameters<typeof getRecordFields>[0], type: string): void {
+    logger.info(`  Type:       ${type} (v${(record as { version: number }).version})`)
+
+    const fields = getRecordFields(record)
+    if (fields.length > 0) {
+        logger.info('\n  Fields:')
+        for (const field of fields) {
+            const label = field.label || field.type
+            logger.info(`    ${label}: ${formatFieldValue(field)}`)
+        }
+    }
+
+    const data = (record as { data?: { notes?: string } }).data
+    if (data?.notes) {
+        logger.info(`\n  Notes:      ${data.notes}`)
+    }
+}
+
+function displayMetadata(vault: { getRecordMetadataByUid: (uid: string) => { owner: boolean; canShare: boolean; canEdit: boolean } | undefined }, uid: string): void {
+    const meta = vault.getRecordMetadataByUid(uid)
+    if (meta) {
+        logger.info('\n  Permissions:')
+        logger.info(`    Owner:     ${meta.owner}`)
+        logger.info(`    Can Share: ${meta.canShare}`)
+        logger.info(`    Can Edit:  ${meta.canEdit}`)
+    }
+}
+
+runExample(getRecord)

--- a/examples/sdk_example/src/records/get_record.ts
+++ b/examples/sdk_example/src/records/get_record.ts
@@ -9,7 +9,7 @@ import {
     getRecordPassword,
     getRecordUrl,
     logger,
-} from 'keeper-sdk'
+} from '@keeper-security/keeper-sdk-javascript'
 import { runExample } from '../utils/runner'
 import { formatFieldValue, LEGACY_RECORD_MAX_VERSION } from '../utils/format'
 

--- a/examples/sdk_example/src/records/list_records.ts
+++ b/examples/sdk_example/src/records/list_records.ts
@@ -1,4 +1,4 @@
-import { login, cleanup, formatRecord, logger } from 'keeper-sdk'
+import { login, cleanup, formatRecord, logger } from '@keeper-security/keeper-sdk-javascript'
 import { runExample } from '../utils/runner'
 
 async function listRecords() {

--- a/examples/sdk_example/src/records/list_records.ts
+++ b/examples/sdk_example/src/records/list_records.ts
@@ -1,0 +1,25 @@
+import { login, cleanup, formatRecord, logger } from 'keeper-sdk'
+import { runExample } from '../utils/runner'
+
+async function listRecords() {
+    const vault = await login()
+
+    try {
+        const records = vault.getRecords()
+
+        if (records.length === 0) {
+            logger.info('No records found in vault.')
+            return
+        }
+
+        logger.info('Vault Records:')
+        for (const record of records) {
+            logger.info(formatRecord(record))
+        }
+        logger.info('-'.repeat(50))
+    } finally {
+        cleanup(vault)
+    }
+}
+
+runExample(listRecords)

--- a/examples/sdk_example/src/records/move_record.ts
+++ b/examples/sdk_example/src/records/move_record.ts
@@ -1,4 +1,4 @@
-import { login, cleanup, suppressLogs, prompt, getRecordTitle, logger } from 'keeper-sdk'
+import { login, cleanup, suppressLogs, prompt, getRecordTitle, logger } from '@keeper-security/keeper-sdk-javascript'
 import { runExample } from '../utils/runner'
 
 async function moveRecord() {

--- a/examples/sdk_example/src/records/move_record.ts
+++ b/examples/sdk_example/src/records/move_record.ts
@@ -1,0 +1,65 @@
+import { login, cleanup, suppressLogs, prompt, getRecordTitle, logger } from 'keeper-sdk'
+import { runExample } from '../utils/runner'
+
+async function moveRecord() {
+    const vault = await login()
+
+    try {
+        const recordInput = await prompt('Enter Record UID or title to move: ')
+        if (!recordInput) {
+            logger.info('No input provided.')
+            return
+        }
+
+        const record = vault.findRecord(recordInput)
+        if (!record) {
+            logger.info(`Record "${recordInput}" not found.`)
+            return
+        }
+
+        const title = getRecordTitle(record)
+        logger.info(`\nRecord: "${title}" (${record.uid})`)
+
+        const folders = vault.getSharedFolders()
+        const userFolders = vault.getUserFolders()
+
+        if (folders.length > 0 || userFolders.length > 0) {
+            logger.info('\nAvailable folders:')
+            for (const uf of userFolders) {
+                const name = uf.data?.name || uf.uid
+                logger.info(`  [User]   ${uf.uid}  ${name}`)
+            }
+            for (const sf of folders) {
+                const name = sf.name || sf.data?.name || sf.uid
+                logger.info(`  [Shared] ${sf.uid}  ${name}`)
+            }
+        }
+
+        const dstFolderUid = await prompt('\nEnter destination folder UID (empty for root): ')
+
+        logger.info(`\nMoving "${title}" to ${dstFolderUid || '(root)'}...`)
+
+        let result
+        {
+            const restore = suppressLogs()
+            try {
+                result = await vault.moveRecord({
+                    recordUid: record.uid,
+                    dstFolderUid: dstFolderUid || '',
+                })
+            } finally {
+                restore()
+            }
+        }
+
+        if (result.success) {
+            logger.info(`Record "${title}" moved successfully.`)
+        } else {
+            logger.error(`Failed to move record: ${result.message}`)
+        }
+    } finally {
+        cleanup(vault)
+    }
+}
+
+runExample(moveRecord)

--- a/examples/sdk_example/src/records/record_history.ts
+++ b/examples/sdk_example/src/records/record_history.ts
@@ -1,0 +1,107 @@
+import { login, cleanup, prompt, getRecordTitle, logger } from 'keeper-sdk'
+import type { HistoryEntry } from 'keeper-sdk'
+import { runExample } from '../utils/runner'
+import { padRight, formatFieldValue } from '../utils/format'
+
+async function recordHistory() {
+    const vault = await login()
+
+    try {
+        const input = await prompt('Enter Record UID or title: ')
+        if (!input) {
+            logger.info('No input provided.')
+            return
+        }
+
+        const record = vault.findRecord(input)
+        if (!record) {
+            logger.info(`Record "${input}" not found.`)
+            return
+        }
+
+        const title = getRecordTitle(record)
+        logger.info(`\nFetching history for "${title}" (${record.uid})...\n`)
+
+        const result = await vault.getRecordHistory(record.uid)
+        const history = result.history
+
+        if (history.length === 0) {
+            logger.info('No history found for this record.')
+            return
+        }
+
+        logger.info('-'.repeat(70))
+        logger.info(
+            padRight('Version', 10) +
+            padRight('Modified By', 35) +
+            'Time Modified'
+        )
+        logger.info('-'.repeat(70))
+
+        const total = history.length
+        for (let i = 0; i < total; i++) {
+            const entry = history[i]
+            const label = i === 0 ? 'Current' : `V.${total - i}`
+            const modified = entry.clientModifiedTime
+                ? new Date(entry.clientModifiedTime).toLocaleString()
+                : ''
+
+            logger.info(
+                padRight(label, 10) +
+                padRight(entry.userName, 35) +
+                modified
+            )
+        }
+        logger.info('-'.repeat(70))
+
+        const viewChoice = await prompt('\nEnter revision number to view details (or press Enter to skip): ')
+        if (!viewChoice) return
+
+        const revNum = parseInt(viewChoice, 10)
+        if (isNaN(revNum) || revNum < 1 || revNum >= total) {
+            logger.info(`Invalid revision. Valid range: 1..${total - 1}`)
+            return
+        }
+
+        const revIndex = total - revNum
+        const rev = history[revIndex]
+
+        displayRevision(rev, `V.${revNum}`)
+    } finally {
+        cleanup(vault)
+    }
+}
+
+function displayRevision(entry: HistoryEntry, label: string) {
+    logger.info('\n' + '-'.repeat(50))
+    logger.info(`Revision: ${label}`)
+    logger.info('-'.repeat(50))
+
+    if (!entry.data) {
+        logger.info('  (could not decrypt revision data)')
+        return
+    }
+
+    logger.info(`  Title:    ${entry.data.title || '(untitled)'}`)
+    logger.info(`  Type:     ${entry.data.type || 'unknown'}`)
+
+    const fields = entry.data.fields || []
+    for (const field of fields) {
+        const fieldLabel = field.label || field.type
+        const values = Array.isArray(field.value) ? field.value : [field.value]
+        logger.info(`  ${fieldLabel}: ${formatFieldValue({ type: field.type, value: values })}`)
+    }
+
+    if (entry.data.notes) {
+        logger.info(`  Notes:    ${entry.data.notes}`)
+    }
+
+    const modified = entry.clientModifiedTime
+        ? new Date(entry.clientModifiedTime).toLocaleString()
+        : 'unknown'
+    logger.info(`  Modified: ${modified}`)
+    logger.info(`  By:       ${entry.userName}`)
+    logger.info('-'.repeat(50))
+}
+
+runExample(recordHistory)

--- a/examples/sdk_example/src/records/record_history.ts
+++ b/examples/sdk_example/src/records/record_history.ts
@@ -1,5 +1,5 @@
-import { login, cleanup, prompt, getRecordTitle, logger } from 'keeper-sdk'
-import type { HistoryEntry } from 'keeper-sdk'
+import { login, cleanup, prompt, getRecordTitle, logger } from '@keeper-security/keeper-sdk-javascript'
+import type { HistoryEntry } from '@keeper-security/keeper-sdk-javascript'
 import { runExample } from '../utils/runner'
 import { padRight, formatFieldValue } from '../utils/format'
 

--- a/examples/sdk_example/src/records/update_record.ts
+++ b/examples/sdk_example/src/records/update_record.ts
@@ -7,8 +7,8 @@ import {
     getRecordType,
     getRecordFields,
     logger,
-} from 'keeper-sdk'
-import type { TypedRecordData, RecordFieldInput } from 'keeper-sdk'
+} from '@keeper-security/keeper-sdk-javascript'
+import type { TypedRecordData, RecordFieldInput } from '@keeper-security/keeper-sdk-javascript'
 import { runExample } from '../utils/runner'
 
 const LEGACY_TYPE_MAPPING: Record<string, string> = { legacy: 'login' }

--- a/examples/sdk_example/src/records/update_record.ts
+++ b/examples/sdk_example/src/records/update_record.ts
@@ -1,0 +1,95 @@
+import {
+    login,
+    cleanup,
+    suppressLogs,
+    prompt,
+    getRecordTitle,
+    getRecordType,
+    getRecordFields,
+    logger,
+} from 'keeper-sdk'
+import type { TypedRecordData, RecordFieldInput } from 'keeper-sdk'
+import { runExample } from '../utils/runner'
+
+const LEGACY_TYPE_MAPPING: Record<string, string> = { legacy: 'login' }
+
+function normalizeRecordType(type: string): string {
+    return LEGACY_TYPE_MAPPING[type] || type
+}
+
+async function updateRecord() {
+    const vault = await login()
+
+    try {
+        const input = await prompt('Enter Record UID or title to update: ')
+        if (!input) {
+            logger.info('No input provided.')
+            return
+        }
+
+        const record = vault.findRecord(input)
+        if (!record) {
+            logger.info(`Record "${input}" not found.`)
+            return
+        }
+
+        const currentTitle = getRecordTitle(record)
+        const currentType = getRecordType(record)
+        const currentFields = getRecordFields(record)
+
+        logger.info(`\nCurrent record: "${currentTitle}" (${currentType})`)
+        if (currentFields.length > 0) {
+            logger.info('Current fields:')
+            for (const f of currentFields) {
+                const label = f.label || f.type
+                const value = f.type === 'password' ? '********' : JSON.stringify(f.value)
+                logger.info(`  ${label}: ${value}`)
+            }
+        }
+
+        logger.info('\nEnter new values (press Enter to keep current):\n')
+
+        const newTitle = await prompt(`Title [${currentTitle}]: `) || currentTitle
+
+        const newFields: RecordFieldInput[] = []
+        for (const field of currentFields) {
+            const label = field.label || field.type
+            const currentVal = field.type === 'password' ? '********' : String(field.value[0] || '')
+            const newVal = await prompt(`${label} [${currentVal}]: `)
+            newFields.push({
+                type: field.type,
+                value: [newVal || field.value[0]],
+                ...(field.label ? { label: field.label } : {}),
+            })
+        }
+
+        const updateData: TypedRecordData = {
+            type: normalizeRecordType(currentType),
+            title: newTitle,
+            fields: newFields,
+        }
+
+        logger.info('\nUpdating record...')
+        let result
+        {
+            const restore = suppressLogs()
+            try {
+                result = await vault.updateRecord(record.uid, updateData)
+            } finally {
+                restore()
+            }
+        }
+
+        if (result.success) {
+            logger.info('Record updated successfully!')
+            logger.info(`  UID:    ${result.recordUid}`)
+            logger.info(`  Status: ${result.status}`)
+        } else {
+            logger.error(`Failed to update record: ${result.status}`)
+        }
+    } finally {
+        cleanup(vault)
+    }
+}
+
+runExample(updateRecord)

--- a/examples/sdk_example/src/sharing/share_record.ts
+++ b/examples/sdk_example/src/sharing/share_record.ts
@@ -1,4 +1,4 @@
-import { login, cleanup, suppressLogs, prompt, getRecordTitle, logger } from 'keeper-sdk'
+import { login, cleanup, suppressLogs, prompt, getRecordTitle, logger } from '@keeper-security/keeper-sdk-javascript'
 import { runExample } from '../utils/runner'
 
 async function shareRecordExample() {

--- a/examples/sdk_example/src/sharing/share_record.ts
+++ b/examples/sdk_example/src/sharing/share_record.ts
@@ -1,0 +1,66 @@
+import { login, cleanup, suppressLogs, prompt, getRecordTitle, logger } from 'keeper-sdk'
+import { runExample } from '../utils/runner'
+
+async function shareRecordExample() {
+    const vault = await login()
+
+    try {
+        const recordInput = await prompt('Enter Record UID or title to share: ')
+        if (!recordInput) {
+            logger.info('No input provided.')
+            return
+        }
+
+        const record = vault.findRecord(recordInput)
+        if (!record) {
+            logger.info(`Record "${recordInput}" not found.`)
+            return
+        }
+
+        const title = getRecordTitle(record)
+        logger.info(`\nRecord: "${title}" (${record.uid})`)
+
+        const email = await prompt('Enter email of user to share with: ')
+        if (!email) {
+            logger.info('No email provided.')
+            return
+        }
+
+        const editAnswer = await prompt('Grant edit permission? (y/N): ')
+        const canEdit = editAnswer.toLowerCase() === 'y'
+
+        const shareAnswer = await prompt('Grant re-share permission? (y/N): ')
+        const canShare = shareAnswer.toLowerCase() === 'y'
+
+        logger.info(`\nSharing "${title}" with ${email}...`)
+        logger.info(`  Can Edit: ${canEdit}`)
+        logger.info(`  Can Share: ${canShare}`)
+
+        let result
+        {
+            const restore = suppressLogs()
+            try {
+                result = await vault.shareRecord({
+                    recordUid: record.uid,
+                    email,
+                    canEdit,
+                    canShare,
+                })
+            } finally {
+                restore()
+            }
+        }
+
+        if (result.success) {
+            logger.info(`\nRecord "${title}" shared with ${email} successfully.`)
+            logger.info(`Status: ${result.status}`)
+        } else {
+            logger.error(`\nFailed to share record: ${result.message}`)
+            logger.error(`Status: ${result.status}`)
+        }
+    } finally {
+        cleanup(vault)
+    }
+}
+
+runExample(shareRecordExample)

--- a/examples/sdk_example/src/utils/format.ts
+++ b/examples/sdk_example/src/utils/format.ts
@@ -1,0 +1,28 @@
+export function padRight(str: string, len: number): string {
+    if (str.length > len) {
+        return len > 1 ? str.substring(0, len - 1) + '\u2026' : str.substring(0, len)
+    }
+    return str.length === len ? str : str + ' '.repeat(len - str.length)
+}
+
+export function formatFieldValue(field: { type: string; value: unknown[] }): string {
+    if (field.type === 'password') {
+        const pw = field.value[0]
+        return pw ? '*'.repeat(String(pw).length) : '(empty)'
+    }
+
+    if (field.type === 'fileRef') {
+        return `[${field.value.length} file(s)]`
+    }
+
+    return field.value
+        .map((v: unknown) => {
+            if (typeof v === 'string') return v
+            if (v && typeof v === 'object') return JSON.stringify(v)
+            return String(v)
+        })
+        .filter(Boolean)
+        .join(', ') || '(empty)'
+}
+
+export const LEGACY_RECORD_MAX_VERSION = 2

--- a/examples/sdk_example/src/utils/runner.ts
+++ b/examples/sdk_example/src/utils/runner.ts
@@ -1,0 +1,9 @@
+import { logger, extractErrorMessage } from 'keeper-sdk'
+
+export function runExample(fn: () => Promise<void>): void {
+    fn()
+        .catch((err) => {
+            logger.error('Error:', extractErrorMessage(err))
+            process.exitCode = 1
+        })
+}

--- a/examples/sdk_example/src/utils/runner.ts
+++ b/examples/sdk_example/src/utils/runner.ts
@@ -1,4 +1,4 @@
-import { logger, extractErrorMessage } from 'keeper-sdk'
+import { logger, extractErrorMessage } from '@keeper-security/keeper-sdk-javascript'
 
 export function runExample(fn: () => Promise<void>): void {
     fn()

--- a/examples/sdk_example/tsconfig.json
+++ b/examples/sdk_example/tsconfig.json
@@ -1,0 +1,20 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es2018",
+        "sourceMap": true,
+        "strict": false,
+        "skipLibCheck": true,
+        "esModuleInterop": true,
+        "types": ["node"],
+        "baseUrl": ".",
+        "paths": {
+            "keeper-sdk": ["../../KeeperSdk/src"],
+            "keeper-sdk/*": ["../../KeeperSdk/src/*"]
+        }
+    },
+    "exclude": ["node_modules"],
+    "ts-node": {
+        "require": ["tsconfig-paths/register"]
+    }
+}

--- a/examples/sdk_example/tsconfig.json
+++ b/examples/sdk_example/tsconfig.json
@@ -9,12 +9,13 @@
         "types": ["node"],
         "baseUrl": ".",
         "paths": {
-            "keeper-sdk": ["../../KeeperSdk/src"],
-            "keeper-sdk/*": ["../../KeeperSdk/src/*"]
+            "@keeper-security/keeper-sdk-javascript": ["../../KeeperSdk/src"],
+            "@keeper-security/keeper-sdk-javascript/*": ["../../KeeperSdk/src/*"]
         }
     },
     "exclude": ["node_modules"],
     "ts-node": {
-        "require": ["tsconfig-paths/register"]
+        "require": ["tsconfig-paths/register"],
+        "preferTsExts": true
     }
 }

--- a/keeperapi/package-lock.json
+++ b/keeperapi/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@keeper-security/keeperapi",
-    "version": "17.1.1",
+    "version": "17.1.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@keeper-security/keeperapi",
-            "version": "17.1.1",
+            "version": "17.1.2",
             "license": "ISC",
             "dependencies": {
                 "@noble/post-quantum": "^0.5.2",
@@ -76,6 +76,7 @@
             "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.9.tgz",
             "integrity": "sha512-G2EgeufBcYw27U4hhoIwFcgc1XU7TlXJ3mv04oOv1WCuo900U/anZSPzEqNjwdjgffkk2Gs0AN0dW1CKVLcG7w==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@ampproject/remapping": "^2.2.0",
                 "@babel/code-frame": "^7.22.5",
@@ -1785,6 +1786,32 @@
             "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
             "dev": true
         },
+        "node_modules/@cspotcode/source-map-support": {
+            "version": "0.8.1",
+            "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+            "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@jridgewell/trace-mapping": "0.3.9"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+            "version": "0.3.9",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+            "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@jridgewell/resolve-uri": "^3.0.3",
+                "@jridgewell/sourcemap-codec": "^1.4.10"
+            }
+        },
         "node_modules/@istanbuljs/load-nyc-config": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -2803,6 +2830,38 @@
                 "node": ">= 10"
             }
         },
+        "node_modules/@tsconfig/node10": {
+            "version": "1.0.12",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
+            "integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true
+        },
+        "node_modules/@tsconfig/node12": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+            "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true
+        },
+        "node_modules/@tsconfig/node14": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+            "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true
+        },
+        "node_modules/@tsconfig/node16": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+            "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true
+        },
         "node_modules/@types/babel__core": {
             "version": "7.20.1",
             "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.1.tgz",
@@ -2914,6 +2973,7 @@
             "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-12.2.3.tgz",
             "integrity": "sha512-GKMHFfv3458yYy+v/N8gjufHO6MSZKCOXpZc5GXIWWy8uldwfmPn98vp81gZ5f9SVw8YYBctgfJ22a2d7AOMeQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@types/linkify-it": "*",
                 "@types/mdurl": "*"
@@ -2930,6 +2990,7 @@
             "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.2.tgz",
             "integrity": "sha512-37MXfxkb0vuIlRKHNxwCkb60PNBpR94u4efQuN4JgIAm66zfCDXGSAFCef9XUWFovX2R1ok6Z7MHhtdVXXkkIw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "undici-types": "~5.26.4"
             }
@@ -2988,6 +3049,7 @@
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
             "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
             "dev": true,
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -3371,6 +3433,7 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
+            "peer": true,
             "dependencies": {
                 "caniuse-lite": "^1.0.30001541",
                 "electron-to-chromium": "^1.4.535",
@@ -3616,6 +3679,14 @@
                 "type": "opencollective",
                 "url": "https://opencollective.com/core-js"
             }
+        },
+        "node_modules/create-require": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+            "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true
         },
         "node_modules/cross-spawn": {
             "version": "7.0.6",
@@ -4655,6 +4726,7 @@
             "resolved": "https://registry.npmjs.org/jest/-/jest-29.6.1.tgz",
             "integrity": "sha512-Nirw5B4nn69rVUZtemCQhwxOBhm0nsp3hmtF4rzCeWD7BkjAXRIji7xWQfnTNbz9g0aVsBX6aZK3n+23LM6uDw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@jest/core": "^29.6.1",
                 "@jest/types": "^29.6.1",
@@ -7295,6 +7367,7 @@
             "integrity": "sha512-dgJaEDDL6x8ASUZ1YqWciTRrdOuYNzoOf27oHNfdyvKqHr5i0FV7FSLU+aIeFjyFgVxrpTOtQUi0BLLBymZaBw==",
             "dev": true,
             "hasInstallScript": true,
+            "peer": true,
             "dependencies": {
                 "@protobufjs/aspromise": "^1.1.2",
                 "@protobufjs/base64": "^1.1.2",
@@ -7669,6 +7742,7 @@
             "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.2.tgz",
             "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
             "dev": true,
+            "peer": true,
             "bin": {
                 "rollup": "dist/bin/rollup"
             },
@@ -8171,6 +8245,7 @@
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
             "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
             "dev": true,
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -8297,6 +8372,14 @@
                 "querystringify": "^2.1.1",
                 "requires-port": "^1.0.0"
             }
+        },
+        "node_modules/v8-compile-cache-lib": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+            "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true
         },
         "node_modules/v8-to-istanbul": {
             "version": "9.1.0",
@@ -8635,6 +8718,7 @@
             "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.9.tgz",
             "integrity": "sha512-G2EgeufBcYw27U4hhoIwFcgc1XU7TlXJ3mv04oOv1WCuo900U/anZSPzEqNjwdjgffkk2Gs0AN0dW1CKVLcG7w==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "@ampproject/remapping": "^2.2.0",
                 "@babel/code-frame": "^7.22.5",
@@ -9805,6 +9889,28 @@
             "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
             "dev": true
         },
+        "@cspotcode/source-map-support": {
+            "version": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+            "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "@jridgewell/trace-mapping": "0.3.9"
+            },
+            "dependencies": {
+                "@jridgewell/trace-mapping": {
+                    "version": "0.3.9",
+                    "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+                    "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "@jridgewell/resolve-uri": "^3.0.3",
+                        "@jridgewell/sourcemap-codec": "^1.4.10"
+                    }
+                }
+            }
+        },
         "@istanbuljs/load-nyc-config": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -10588,6 +10694,30 @@
             "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
             "dev": true
         },
+        "@tsconfig/node10": {
+            "version": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
+            "integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
+            "dev": true,
+            "optional": true
+        },
+        "@tsconfig/node12": {
+            "version": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+            "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+            "dev": true,
+            "optional": true
+        },
+        "@tsconfig/node14": {
+            "version": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+            "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+            "dev": true,
+            "optional": true
+        },
+        "@tsconfig/node16": {
+            "version": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+            "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+            "dev": true,
+            "optional": true
+        },
         "@types/babel__core": {
             "version": "7.20.1",
             "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.1.tgz",
@@ -10699,6 +10829,7 @@
             "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-12.2.3.tgz",
             "integrity": "sha512-GKMHFfv3458yYy+v/N8gjufHO6MSZKCOXpZc5GXIWWy8uldwfmPn98vp81gZ5f9SVw8YYBctgfJ22a2d7AOMeQ==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "@types/linkify-it": "*",
                 "@types/mdurl": "*"
@@ -10715,6 +10846,7 @@
             "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.2.tgz",
             "integrity": "sha512-37MXfxkb0vuIlRKHNxwCkb60PNBpR94u4efQuN4JgIAm66zfCDXGSAFCef9XUWFovX2R1ok6Z7MHhtdVXXkkIw==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "undici-types": "~5.26.4"
             }
@@ -10771,7 +10903,8 @@
             "version": "8.10.0",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
             "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "acorn-globals": {
             "version": "7.0.1",
@@ -11059,6 +11192,7 @@
             "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.1.tgz",
             "integrity": "sha512-FEVc202+2iuClEhZhrWy6ZiAcRLvNMyYcxZ8raemul1DYVOVdFsbqckWLdsixQZCpJlwe77Z3UTalE7jsjnKfQ==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "caniuse-lite": "^1.0.30001541",
                 "electron-to-chromium": "^1.4.535",
@@ -11233,6 +11367,12 @@
             "requires": {
                 "browserslist": "^4.22.1"
             }
+        },
+        "create-require": {
+            "version": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+            "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+            "dev": true,
+            "optional": true
         },
         "cross-spawn": {
             "version": "7.0.6",
@@ -11988,6 +12128,7 @@
             "resolved": "https://registry.npmjs.org/jest/-/jest-29.6.1.tgz",
             "integrity": "sha512-Nirw5B4nn69rVUZtemCQhwxOBhm0nsp3hmtF4rzCeWD7BkjAXRIji7xWQfnTNbz9g0aVsBX6aZK3n+23LM6uDw==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "@jest/core": "^29.6.1",
                 "@jest/types": "^29.6.1",
@@ -13973,6 +14114,7 @@
             "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.6.tgz",
             "integrity": "sha512-dgJaEDDL6x8ASUZ1YqWciTRrdOuYNzoOf27oHNfdyvKqHr5i0FV7FSLU+aIeFjyFgVxrpTOtQUi0BLLBymZaBw==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "@protobufjs/aspromise": "^1.1.2",
                 "@protobufjs/base64": "^1.1.2",
@@ -14255,6 +14397,7 @@
             "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.2.tgz",
             "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "fsevents": "~2.3.2"
             }
@@ -14617,7 +14760,8 @@
             "version": "4.6.4",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
             "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "uc.micro": {
             "version": "1.0.6",
@@ -14696,6 +14840,12 @@
                 "querystringify": "^2.1.1",
                 "requires-port": "^1.0.0"
             }
+        },
+        "v8-compile-cache-lib": {
+            "version": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+            "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+            "dev": true,
+            "optional": true
         },
         "v8-to-istanbul": {
             "version": "9.1.0",

--- a/keeperapi/package-lock.json
+++ b/keeperapi/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@keeper-security/keeperapi",
-    "version": "17.1.2",
+    "version": "17.1.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@keeper-security/keeperapi",
-            "version": "17.1.2",
+            "version": "17.1.1",
             "license": "ISC",
             "dependencies": {
                 "@noble/post-quantum": "^0.5.2",
@@ -76,7 +76,6 @@
             "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.9.tgz",
             "integrity": "sha512-G2EgeufBcYw27U4hhoIwFcgc1XU7TlXJ3mv04oOv1WCuo900U/anZSPzEqNjwdjgffkk2Gs0AN0dW1CKVLcG7w==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@ampproject/remapping": "^2.2.0",
                 "@babel/code-frame": "^7.22.5",
@@ -1786,32 +1785,6 @@
             "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
             "dev": true
         },
-        "node_modules/@cspotcode/source-map-support": {
-            "version": "0.8.1",
-            "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
-            "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "@jridgewell/trace-mapping": "0.3.9"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
-            "version": "0.3.9",
-            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
-            "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "@jridgewell/resolve-uri": "^3.0.3",
-                "@jridgewell/sourcemap-codec": "^1.4.10"
-            }
-        },
         "node_modules/@istanbuljs/load-nyc-config": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -2830,38 +2803,6 @@
                 "node": ">= 10"
             }
         },
-        "node_modules/@tsconfig/node10": {
-            "version": "1.0.12",
-            "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
-            "integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true
-        },
-        "node_modules/@tsconfig/node12": {
-            "version": "1.0.11",
-            "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
-            "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true
-        },
-        "node_modules/@tsconfig/node14": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
-            "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true
-        },
-        "node_modules/@tsconfig/node16": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
-            "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true
-        },
         "node_modules/@types/babel__core": {
             "version": "7.20.1",
             "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.1.tgz",
@@ -2973,7 +2914,6 @@
             "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-12.2.3.tgz",
             "integrity": "sha512-GKMHFfv3458yYy+v/N8gjufHO6MSZKCOXpZc5GXIWWy8uldwfmPn98vp81gZ5f9SVw8YYBctgfJ22a2d7AOMeQ==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@types/linkify-it": "*",
                 "@types/mdurl": "*"
@@ -2990,7 +2930,6 @@
             "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.2.tgz",
             "integrity": "sha512-37MXfxkb0vuIlRKHNxwCkb60PNBpR94u4efQuN4JgIAm66zfCDXGSAFCef9XUWFovX2R1ok6Z7MHhtdVXXkkIw==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "undici-types": "~5.26.4"
             }
@@ -3049,7 +2988,6 @@
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
             "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
             "dev": true,
-            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -3433,7 +3371,6 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
-            "peer": true,
             "dependencies": {
                 "caniuse-lite": "^1.0.30001541",
                 "electron-to-chromium": "^1.4.535",
@@ -3679,14 +3616,6 @@
                 "type": "opencollective",
                 "url": "https://opencollective.com/core-js"
             }
-        },
-        "node_modules/create-require": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-            "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true
         },
         "node_modules/cross-spawn": {
             "version": "7.0.6",
@@ -4726,7 +4655,6 @@
             "resolved": "https://registry.npmjs.org/jest/-/jest-29.6.1.tgz",
             "integrity": "sha512-Nirw5B4nn69rVUZtemCQhwxOBhm0nsp3hmtF4rzCeWD7BkjAXRIji7xWQfnTNbz9g0aVsBX6aZK3n+23LM6uDw==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@jest/core": "^29.6.1",
                 "@jest/types": "^29.6.1",
@@ -7367,7 +7295,6 @@
             "integrity": "sha512-dgJaEDDL6x8ASUZ1YqWciTRrdOuYNzoOf27oHNfdyvKqHr5i0FV7FSLU+aIeFjyFgVxrpTOtQUi0BLLBymZaBw==",
             "dev": true,
             "hasInstallScript": true,
-            "peer": true,
             "dependencies": {
                 "@protobufjs/aspromise": "^1.1.2",
                 "@protobufjs/base64": "^1.1.2",
@@ -7742,7 +7669,6 @@
             "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.2.tgz",
             "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
             "dev": true,
-            "peer": true,
             "bin": {
                 "rollup": "dist/bin/rollup"
             },
@@ -8245,7 +8171,6 @@
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
             "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
             "dev": true,
-            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -8372,14 +8297,6 @@
                 "querystringify": "^2.1.1",
                 "requires-port": "^1.0.0"
             }
-        },
-        "node_modules/v8-compile-cache-lib": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-            "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true
         },
         "node_modules/v8-to-istanbul": {
             "version": "9.1.0",
@@ -8718,7 +8635,6 @@
             "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.9.tgz",
             "integrity": "sha512-G2EgeufBcYw27U4hhoIwFcgc1XU7TlXJ3mv04oOv1WCuo900U/anZSPzEqNjwdjgffkk2Gs0AN0dW1CKVLcG7w==",
             "dev": true,
-            "peer": true,
             "requires": {
                 "@ampproject/remapping": "^2.2.0",
                 "@babel/code-frame": "^7.22.5",
@@ -9889,28 +9805,6 @@
             "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
             "dev": true
         },
-        "@cspotcode/source-map-support": {
-            "version": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
-            "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-            "dev": true,
-            "optional": true,
-            "requires": {
-                "@jridgewell/trace-mapping": "0.3.9"
-            },
-            "dependencies": {
-                "@jridgewell/trace-mapping": {
-                    "version": "0.3.9",
-                    "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
-                    "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "@jridgewell/resolve-uri": "^3.0.3",
-                        "@jridgewell/sourcemap-codec": "^1.4.10"
-                    }
-                }
-            }
-        },
         "@istanbuljs/load-nyc-config": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -10694,30 +10588,6 @@
             "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
             "dev": true
         },
-        "@tsconfig/node10": {
-            "version": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
-            "integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
-            "dev": true,
-            "optional": true
-        },
-        "@tsconfig/node12": {
-            "version": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
-            "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-            "dev": true,
-            "optional": true
-        },
-        "@tsconfig/node14": {
-            "version": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
-            "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-            "dev": true,
-            "optional": true
-        },
-        "@tsconfig/node16": {
-            "version": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
-            "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
-            "dev": true,
-            "optional": true
-        },
         "@types/babel__core": {
             "version": "7.20.1",
             "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.1.tgz",
@@ -10829,7 +10699,6 @@
             "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-12.2.3.tgz",
             "integrity": "sha512-GKMHFfv3458yYy+v/N8gjufHO6MSZKCOXpZc5GXIWWy8uldwfmPn98vp81gZ5f9SVw8YYBctgfJ22a2d7AOMeQ==",
             "dev": true,
-            "peer": true,
             "requires": {
                 "@types/linkify-it": "*",
                 "@types/mdurl": "*"
@@ -10846,7 +10715,6 @@
             "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.2.tgz",
             "integrity": "sha512-37MXfxkb0vuIlRKHNxwCkb60PNBpR94u4efQuN4JgIAm66zfCDXGSAFCef9XUWFovX2R1ok6Z7MHhtdVXXkkIw==",
             "dev": true,
-            "peer": true,
             "requires": {
                 "undici-types": "~5.26.4"
             }
@@ -10903,8 +10771,7 @@
             "version": "8.10.0",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
             "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "acorn-globals": {
             "version": "7.0.1",
@@ -11192,7 +11059,6 @@
             "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.1.tgz",
             "integrity": "sha512-FEVc202+2iuClEhZhrWy6ZiAcRLvNMyYcxZ8raemul1DYVOVdFsbqckWLdsixQZCpJlwe77Z3UTalE7jsjnKfQ==",
             "dev": true,
-            "peer": true,
             "requires": {
                 "caniuse-lite": "^1.0.30001541",
                 "electron-to-chromium": "^1.4.535",
@@ -11367,12 +11233,6 @@
             "requires": {
                 "browserslist": "^4.22.1"
             }
-        },
-        "create-require": {
-            "version": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-            "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-            "dev": true,
-            "optional": true
         },
         "cross-spawn": {
             "version": "7.0.6",
@@ -12128,7 +11988,6 @@
             "resolved": "https://registry.npmjs.org/jest/-/jest-29.6.1.tgz",
             "integrity": "sha512-Nirw5B4nn69rVUZtemCQhwxOBhm0nsp3hmtF4rzCeWD7BkjAXRIji7xWQfnTNbz9g0aVsBX6aZK3n+23LM6uDw==",
             "dev": true,
-            "peer": true,
             "requires": {
                 "@jest/core": "^29.6.1",
                 "@jest/types": "^29.6.1",
@@ -14114,7 +13973,6 @@
             "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.6.tgz",
             "integrity": "sha512-dgJaEDDL6x8ASUZ1YqWciTRrdOuYNzoOf27oHNfdyvKqHr5i0FV7FSLU+aIeFjyFgVxrpTOtQUi0BLLBymZaBw==",
             "dev": true,
-            "peer": true,
             "requires": {
                 "@protobufjs/aspromise": "^1.1.2",
                 "@protobufjs/base64": "^1.1.2",
@@ -14397,7 +14255,6 @@
             "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.2.tgz",
             "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
             "dev": true,
-            "peer": true,
             "requires": {
                 "fsevents": "~2.3.2"
             }
@@ -14760,8 +14617,7 @@
             "version": "4.6.4",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
             "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "uc.micro": {
             "version": "1.0.6",
@@ -14840,12 +14696,6 @@
                 "querystringify": "^2.1.1",
                 "requires-port": "^1.0.0"
             }
-        },
-        "v8-compile-cache-lib": {
-            "version": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-            "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-            "dev": true,
-            "optional": true
         },
         "v8-to-istanbul": {
             "version": "9.1.0",

--- a/keeperapi/src/commands.ts
+++ b/keeperapi/src/commands.ts
@@ -274,6 +274,27 @@ export const recordPreDeleteCommand = (
 export const recordDeleteCommand = (request: RecordDeleteRequest): RestCommand<RecordDeleteRequest, KeeperResponse> =>
     createCommand(request, 'delete')
 
+export type GetRecordHistoryRequest = {
+    record_uid: string
+    client_time: number
+}
+
+export type GetRecordHistoryHistoryEntry = {
+    revision: number
+    version: number
+    user_name?: string
+    client_modified_time?: number
+    data?: string
+}
+
+export type GetRecordHistoryResponse = KeeperResponse & {
+    history?: GetRecordHistoryHistoryEntry[]
+}
+
+export const getRecordHistoryCommand = (
+    request: GetRecordHistoryRequest
+): RestCommand<GetRecordHistoryRequest, GetRecordHistoryResponse> => createCommand(request, 'get_record_history')
+
 export type EnterpriseSettingInclude =
     | 'AuditSyncConfig'
     | 'AuditSyncContext'

--- a/keeperapi/src/restMessages.ts
+++ b/keeperapi/src/restMessages.ts
@@ -444,6 +444,16 @@ export const recordsUpdateMessage = (
 ): RestMessage<Records.IRecordsUpdateRequest, Records.IRecordsModifyResponse> =>
     createMessage(data, 'vault/records_update', Records.RecordsUpdateRequest, Records.RecordsModifyResponse)
 
+export const recordsShareUpdateMessage = (
+    data: Records.IRecordShareUpdateRequest
+): RestMessage<Records.IRecordShareUpdateRequest, Records.IRecordShareUpdateResponse> =>
+    createMessage(
+        data,
+        'vault/records_share_update',
+        Records.RecordShareUpdateRequest,
+        Records.RecordShareUpdateResponse
+    )
+
 export const recordsRevertMessage = (
     data: Records.IRecordsRevertRequest
 ): RestMessage<Records.IRecordsRevertRequest, Records.IRecordsModifyResponse> =>


### PR DESCRIPTION
# Login & Records Implementation

## Summary
Adds KeeperSdk wrapper and interactive CLI examples for authentication and vault record operations.

## Authentication
- **Password login** — Master password authentication with retry logic and masked input.
- **Session token login** — Login using an existing session token for pre-authenticated workflows.
- **Persistent login** — Automatic session resumption via clone code from `~/.keeper/config.json`.

## Records
- CRUD operations for vault records: list, get, add (v2/v3), update, delete, move, revision history, and password lookup with clipboard copy.

## Sharing
- Share and unshare records with other Keeper users via public key encryption.
