### PR TITLE
Prepare keeper-sdk-javascript wrapper for publish

### DIFF
--- a/KeeperSdk/package-lock.json
+++ b/KeeperSdk/package-lock.json
@@ -7,8 +7,9 @@
         "": {
             "name": "@keeper-security/keeper-sdk-javascript",
             "version": "1.0.0",
+            "license": "ISC",
             "dependencies": {
-                "@keeper-security/keeperapi": "17.1.0",
+                "@keeper-security/keeperapi": "17.1.3",
                 "ts-node": "^10.7.0",
                 "typescript": "^4.6.3"
             },
@@ -55,9 +56,9 @@
             }
         },
         "node_modules/@keeper-security/keeperapi": {
-            "version": "17.1.0",
-            "resolved": "https://registry.npmjs.org/@keeper-security/keeperapi/-/keeperapi-17.1.0.tgz",
-            "integrity": "sha512-BV1o72g1BXz3Agjw0l6kLlS5SOvWCJ0qD2RcEXPAvMQJcq0O8SLaf2KhIG/dGHPHdNZ5Dod4+cI0sAfnpZeYZw==",
+            "version": "17.1.3",
+            "resolved": "https://registry.npmjs.org/@keeper-security/keeperapi/-/keeperapi-17.1.3.tgz",
+            "integrity": "sha512-xLRST98iT/aoF5gyYjMuOxXXtNQdOFWjrkfx+gxNo9SbSLFlNCeXLGsCSux23AsNXKvyAQnrmDmg04oAUFWPvA==",
             "license": "ISC",
             "dependencies": {
                 "@noble/post-quantum": "^0.5.2",

--- a/KeeperSdk/package.json
+++ b/KeeperSdk/package.json
@@ -2,6 +2,12 @@
     "name": "@keeper-security/keeper-sdk-javascript",
     "version": "1.0.0",
     "description": "High-level wrapper for Keeper Security JavaScript SDK",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/Keeper-Security/keeper-sdk-javascript.git",
+        "directory": "KeeperSdk"
+    },
+    "license": "ISC",
     "main": "src/index.ts",
     "scripts": {
         "build": "tsc",
@@ -15,7 +21,7 @@
         "prepublishOnly": "npm run build"
     },
     "dependencies": {
-        "@keeper-security/keeperapi": "17.1.0",
+        "@keeper-security/keeperapi": "17.1.3",
         "ts-node": "^10.7.0",
         "typescript": "^4.6.3"
     },


### PR DESCRIPTION
- Fix build by pointing at compatible keeperapi version
- add license and repository fields to package.json