### PR TITLE
Add role enforcement and CRUD commands to keeperapi

### DIFF
--- a/KeeperSdk/package.json
+++ b/KeeperSdk/package.json
@@ -21,7 +21,7 @@
         "prepublishOnly": "npm run build"
     },
     "dependencies": {
-        "@keeper-security/keeperapi": "17.1.3",
+        "@keeper-security/keeperapi": "17.1.4",
         "ts-node": "^10.7.0",
         "typescript": "^4.6.3"
     },

--- a/keeperapi/package.json
+++ b/keeperapi/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@keeper-security/keeperapi",
     "description": "Keeper API Javascript SDK",
-    "version": "17.2.3",
+    "version": "17.2.4",
     "browser": "dist/index.es.js",
     "main": "dist/index.cjs.js",
     "types": "dist/node/index.d.ts",

--- a/keeperapi/src/commands.ts
+++ b/keeperapi/src/commands.ts
@@ -189,6 +189,49 @@ export const roleEnforcementAddCommand = (
     request: RoleEnforcementAddRequest
 ): RestCommand<RoleEnforcementAddRequest, KeeperResponse> => createCommand(request, 'role_enforcement_add')
 
+export const roleEnforcementUpdateCommand = (
+    request: RoleEnforcementAddRequest
+): RestCommand<RoleEnforcementAddRequest, KeeperResponse> => createCommand(request, 'role_enforcement_update')
+
+export type RoleEnforcementRemoveRequest = {
+    role_id: number
+    enforcement: string
+}
+
+export const roleEnforcementRemoveCommand = (
+    request: RoleEnforcementRemoveRequest
+): RestCommand<RoleEnforcementRemoveRequest, KeeperResponse> => createCommand(request, 'role_enforcement_remove')
+
+export type EnterpriseAllocateIdsRequest = {
+    number_requested: number
+}
+
+export const enterpriseAllocateIdsCommand = (
+    request: EnterpriseAllocateIdsRequest
+): RestCommand<EnterpriseAllocateIdsRequest, KeeperResponse & { base_id: number; number_allocated: number }> =>
+    createCommand(request, 'enterprise_allocate_ids')
+
+export type RoleEditRequest = {
+    role_id: number
+    node_id: number
+    encrypted_data: string
+    visible_below: boolean
+    new_user_inherit: boolean
+}
+
+export const roleAddCommand = (request: RoleEditRequest): RestCommand<RoleEditRequest, KeeperResponse> =>
+    createCommand(request, 'role_add')
+
+export const roleUpdateCommand = (request: RoleEditRequest): RestCommand<RoleEditRequest, KeeperResponse> =>
+    createCommand(request, 'role_update')
+
+export type RoleDeleteRequest = {
+    role_id: number
+}
+
+export const roleDeleteCommand = (request: RoleDeleteRequest): RestCommand<RoleDeleteRequest, KeeperResponse> =>
+    createCommand(request, 'role_delete')
+
 export type MoveRequest = {
     to_type: 'user_folder' | 'shared_folder' | 'shared_folder_folder'
     to_uid?: string


### PR DESCRIPTION
## Summary

Add role-related REST commands to `keeperapi`.

## Changes

- Add role enforcement update and remove commands
- Add role create, update, and delete commands
- Add enterprise ID allocation command
