### PR TITLE
BE-7712 Fixed an issue where child KD folder keys are not decrypted correctly

### DIFF
--- a/keeperapi/package-lock.json
+++ b/keeperapi/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@keeper-security/keeperapi",
-    "version": "17.2.6",
+    "version": "17.2.7",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@keeper-security/keeperapi",
-            "version": "17.2.6",
+            "version": "17.2.7",
             "license": "ISC",
             "dependencies": {
                 "@noble/post-quantum": "^0.5.2",

--- a/keeperapi/package.json
+++ b/keeperapi/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@keeper-security/keeperapi",
     "description": "Keeper API Javascript SDK",
-    "version": "17.2.6",
+    "version": "17.2.7",
     "browser": "dist/index.es.js",
     "main": "dist/index.cjs.js",
     "types": "dist/node/index.d.ts",

--- a/keeperapi/src/vault.ts
+++ b/keeperapi/src/vault.ts
@@ -1160,7 +1160,6 @@ const processKdRemovedFolders = async (
 const processKdFolderKeys = async (storage: VaultStorage, folderKeys?: Folder.IFolderKey[] | null) => {
     if (!folderKeys) return
     const encryptedByDataKeyMap: UnwrapKeyMap = {}
-    const encryptedByParentKeyMap: UnwrapKeyMap = {}
     const encryptedByDataKey = folderKeys.filter(
         (key) => key.encryptedBy === Folder.FolderKeyEncryptionType.ENCRYPTED_BY_USER_KEY
     )
@@ -1170,7 +1169,6 @@ const processKdFolderKeys = async (storage: VaultStorage, folderKeys?: Folder.IF
     for (const key of encryptedByDataKey) {
         if (!key.folderUid || !key.folderKey || !key.parentUid || isNil(key.encryptedBy)) continue
         const folderUid = webSafe64FromBytes(key.folderUid)
-        const parentUid = webSafe64FromBytes(key.parentUid)
         encryptedByDataKeyMap[folderUid] = {
             data: key.folderKey,
             dataId: folderUid,
@@ -1184,15 +1182,8 @@ const processKdFolderKeys = async (storage: VaultStorage, folderKeys?: Folder.IF
         if (!key.folderUid || !key.folderKey || !key.parentUid || isNil(key.encryptedBy)) continue
         const folderUid = webSafe64FromBytes(key.folderUid)
         const parentUid = webSafe64FromBytes(key.parentUid)
-        encryptedByParentKeyMap[folderUid] = {
-            data: key.folderKey,
-            dataId: folderUid,
-            keyId: parentUid,
-            encryptionType: 'gcm',
-            unwrappedType: 'aes',
-        }
+        await platform.unwrapKey(key.folderKey, folderUid, parentUid, 'gcm', 'aes', storage)
     }
-    await platform.unwrapKeys(encryptedByParentKeyMap, storage)
 }
 
 const processKdFolderAccesses = async (


### PR DESCRIPTION
## Changes
1. Fixed an issue where child KD folder keys are not decrypted correctly
Before the fix, the `unwrapKeys()` was used to decrypt child KD folder keys. But the function used the `Promise.all()` under the hood, which runs decryption of keys asynchronously. This caused issues when child folders have parent-child relationship where the child's key should be decrypted by the parent key. Due to the async process, there was a chance where the child key was processed before the parent's key, which resulted in the decryption failure. To avoid the issue, the `unwrapKey()` was used instead.
2. Version bump to `v17.2.7`