### PR TITLE
Supply-chain security: use npm ci in CI workflows and add min-release-age to keeperapi

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
           node-version: '24'
 
       - name: Lib - Install
-        run: npm i
+        run: npm ci
         working-directory: ./keeperapi
         env:
           NPM_TOKEN: ""

--- a/.github/workflows/publish.keeper-sdk.yml
+++ b/.github/workflows/publish.keeper-sdk.yml
@@ -26,7 +26,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Publish package
         run: npm publish

--- a/.github/workflows/publish.npm.yml
+++ b/.github/workflows/publish.npm.yml
@@ -26,7 +26,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Publish package
         run: npm publish

--- a/keeperapi/.npmrc
+++ b/keeperapi/.npmrc
@@ -1,1 +1,2 @@
 //registry.npmjs.org/:_authToken=${NPM_TOKEN}
+min-release-age=3


### PR DESCRIPTION
Switch all CI workflows from npm install/npm i to npm ci for reproducible, lock-file-enforced installs. Add min-release-age=3 to keeperapi/.npmrc to prevent installing packages published less than 3 days ago.