### PR TITLE
Use preserveModules for browser dist to enable proto.js tree-shaking by downstream bundlers

### DIFF
--- a/keeperapi/package-lock.json
+++ b/keeperapi/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@keeper-security/keeperapi",
-    "version": "18.0.0",
+    "version": "18.0.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@keeper-security/keeperapi",
-            "version": "18.0.0",
+            "version": "18.0.1",
             "license": "ISC",
             "dependencies": {
                 "@noble/post-quantum": "^0.5.2",

--- a/keeperapi/package.json
+++ b/keeperapi/package.json
@@ -5,7 +5,9 @@
     "browser": "dist/browser/index.js",
     "main": "dist/index.cjs.js",
     "types": "dist/node/index.d.ts",
-    "sideEffects": ["**/configureProtobuf*"],
+    "sideEffects": [
+        "**/configureProtobuf*"
+    ],
     "repository": "https://github.com/Keeper-Security/keeper-sdk-javascript",
     "license": "ISC",
     "engines": {

--- a/keeperapi/package.json
+++ b/keeperapi/package.json
@@ -1,10 +1,11 @@
 {
     "name": "@keeper-security/keeperapi",
     "description": "Keeper API Javascript SDK",
-    "version": "18.0.0",
-    "browser": "dist/index.es.js",
+    "version": "18.0.1",
+    "browser": "dist/browser/index.js",
     "main": "dist/index.cjs.js",
     "types": "dist/node/index.d.ts",
+    "sideEffects": ["**/configureProtobuf*"],
     "repository": "https://github.com/Keeper-Security/keeper-sdk-javascript",
     "license": "ISC",
     "engines": {

--- a/keeperapi/rollup.config.js
+++ b/keeperapi/rollup.config.js
@@ -8,14 +8,12 @@ export default [
         input: 'src/browser/index.ts',
         output: [
             {
-                file: pkg.browser,
+                dir: 'dist',
                 format: 'es',
+                preserveModules: true,
+                preserveModulesRoot: 'src',
                 sourcemap: true,
             },
-            // {
-            //     file: pkg.browsertest,
-            //     format: 'cjs',
-            // },
         ],
         external: [...Object.keys(pkg.dependencies || {}), 'protobufjs/minimal', '@noble/post-quantum/ml-kem.js'],
         plugins: [


### PR DESCRIPTION
proto.js is 16.1 MB unminified / 4.81 MiB minified. With a monolithic ES bundle, any keeperapi import pulled in the full file. preserveModules outputs one file per source module so webpack can exclude proto.js entirely from bundles that don't use protobuf (e.g. tabWorker: 4.81 MiB → 40 KB minified, browser action: eliminated as an async chunk). sideEffects lists configureProtobuf so it is never dropped.