### PR TITLE
BE-7755: preserve platform-connect side-effects in sideEffects allowlist

### DIFF
--- a/keeperapi/package.json
+++ b/keeperapi/package.json
@@ -6,7 +6,9 @@
     "main": "dist/index.cjs.js",
     "types": "dist/node/index.d.ts",
     "sideEffects": [
-        "**/configureProtobuf*"
+        "**/configureProtobuf*",
+        "**/browser/index.js",
+        "**/worker/browserWorker.js"
     ],
     "repository": "https://github.com/Keeper-Security/keeper-sdk-javascript",
     "license": "ISC",


### PR DESCRIPTION
[BE-7755](https://keeper.atlassian.net/browse/BE-7755)

## Summary
The `sideEffects` allowlist (`["**/configureProtobuf*"]`) was scoped to let downstream bundlers tree-shake `proto.js`. A consequence is that every module **not** listed is treated as side-effect-free — including the entry modules that call `connectPlatform(...)`. Downstream bundlers (e.g. webpack) then drop that call, the module-level `platform` binding is never initialized, and a consumer that imports named exports and runs crypto in a separate bundle/realm — such as an MV3 offscreen document — sees `platform` as `undefined` at runtime and crypto fails.

### How `sideEffects` behaves
- **Omitted**: bundlers assume every module *may* have side effects, so nothing is dropped and `connectPlatform` always runs.
- **`false`**: every module is treated as pure, so all side-effect-only imports are eligible for removal.
- **Allowlist `[globs]`** (current): only the listed files may have side effects; everything else is treated as pure. The `configureProtobuf*` allowlist unintentionally excluded the `connectPlatform` entry modules.

This PR adds the browser entry modules to the allowlist, so bundlers preserve the platform connection while still tree-shaking `proto.js`:
- `dist/browser/index.js` — `connectPlatform(browserPlatform)`
- `dist/worker/browserWorker.js` — browser worker entry

The change is additive metadata only: it makes consuming bundlers more conservative and cannot alter runtime behavior for consumers that were already working.

[BE-7755]: https://keeper.atlassian.net/browse/BE-7755?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ