### PR TITLE
BE-7755: bump keeperapi to 18.0.4

### DIFF
--- a/keeperapi/package.json
+++ b/keeperapi/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@keeper-security/keeperapi",
     "description": "Keeper API Javascript SDK",
-    "version": "18.0.3",
+    "version": "18.0.4",
     "browser": "dist/browser/index.js",
     "main": "dist/index.cjs.js",
     "types": "dist/node/index.d.ts",


### PR DESCRIPTION
[BE-7755](https://keeper.atlassian.net/browse/BE-7755)

## Summary
Bump `@keeper-security/keeperapi` to `18.0.4` to release the `sideEffects` fix from #196, which stops downstream bundlers tree-shaking the `connectPlatform(...)` side-effect out of the browser entry modules.

[BE-7755]: https://keeper.atlassian.net/browse/BE-7755?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ