### PR TITLE
update keeperapi version

### DIFF
--- a/keeperapi/package.json
+++ b/keeperapi/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@keeper-security/keeperapi",
     "description": "Keeper API Javascript SDK",
-    "version": "18.0.4",
+    "version": "18.0.5",
     "browser": "dist/browser/index.js",
     "main": "dist/index.cjs.js",
     "types": "dist/node/index.d.ts",


### PR DESCRIPTION
Keeper API rest messages were added in #204 but the version update was missed during checkout which caused the rest messages to not be pulled when building `keepersdk` from `npm`. This change aims to fix it by incrementing `keeperapi` package version.