### PR TITLE
replaced cp command with fs in keeperapi build script

### DIFF
--- a/keeperapi/package.json
+++ b/keeperapi/package.json
@@ -17,14 +17,14 @@
     },
     "scripts": {
         "start": "rollup -cw",
-        "build": "node ./scripts/cleanDistFolder.js && rollup -c && cp src/proto.d.ts dist",
+        "build": "node ./scripts/cleanDistFolder.js && rollup -c && node ./scripts/copyProtoDts.js",
         "update-proto:es6": "node scripts/generate-proto.mjs",
         "format": "prettier --write .",
         "format:check": "prettier --check .",
         "test": "jest",
         "types": "tsc --watch",
         "types:ci": "tsc",
-        "prepublishOnly": "rollup -c && cp src/proto.d.ts dist",
+        "prepublishOnly": "rollup -c && node ./scripts/copyProtoDts.js",
         "publish-to-npm": "npm publish"
     },
     "dependencies": {

--- a/keeperapi/scripts/copyProtoDts.js
+++ b/keeperapi/scripts/copyProtoDts.js
@@ -1,0 +1,7 @@
+const fs = require('fs')
+const path = require('path')
+
+const src = path.join(__dirname, '..', 'src', 'proto.d.ts')
+const dest = path.join(__dirname, '..', 'dist', 'proto.d.ts')
+
+fs.copyFileSync(src, dest)


### PR DESCRIPTION
The current version of `cp` command does not work on windows and fails to copy the files. to fix this a js script which executes on node env is added which runs using `fs` and `path` packages