### PR TITLE
BE-7952 Wrap the platform.unwrapKey with try-catch block in the processKdFolderKeys to avoid complete sync down failure

### DIFF
--- a/keeperapi/package-lock.json
+++ b/keeperapi/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@keeper-security/keeperapi",
-    "version": "18.0.6",
+    "version": "18.0.7",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@keeper-security/keeperapi",
-            "version": "18.0.6",
+            "version": "18.0.7",
             "license": "ISC",
             "dependencies": {
                 "@noble/post-quantum": "^0.5.2",

--- a/keeperapi/package.json
+++ b/keeperapi/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@keeper-security/keeperapi",
     "description": "Keeper API Javascript SDK",
-    "version": "18.0.6",
+    "version": "18.0.7",
     "browser": "dist/browser/index.js",
     "main": "dist/index.cjs.js",
     "types": "dist/node/index.d.ts",

--- a/keeperapi/src/browser/platform.ts
+++ b/keeperapi/src/browser/platform.ts
@@ -613,13 +613,9 @@ export const browserPlatform: Platform = class {
     }
 
     static async importECCJsonWebKey(jwk: JsonWebKey, extractable = true): Promise<CryptoKey> {
-        return await crypto.subtle.importKey(
-            'jwk',
-            jwk,
-            { name: 'ECDH', namedCurve: 'P-256' },
-            extractable,
-            ['deriveBits']
-        )
+        return await crypto.subtle.importKey('jwk', jwk, { name: 'ECDH', namedCurve: 'P-256' }, extractable, [
+            'deriveBits',
+        ])
     }
 
     static async ecdhComputeSharedSecret(

--- a/keeperapi/src/vault.ts
+++ b/keeperapi/src/vault.ts
@@ -1121,8 +1121,8 @@ const processKdRecordLinks = async (storage: VaultStorage, keeperDriveRecordLink
                 parentRecordUid,
             })
         } catch (e: any) {
-            console.error(
-                `[ks] The record link for ${childRecordUid} cannot be decrypted by ${parentRecordUid} (${e.message})`
+            logger.error(
+                `[kd] The record link for ${childRecordUid} cannot be decrypted by ${parentRecordUid} (${e.message})`
             )
         }
     }
@@ -1185,7 +1185,7 @@ const processKdFolderKeys = async (storage: VaultStorage, folderKeys?: Folder.IF
         try {
             await platform.unwrapKey(key.folderKey, folderUid, parentUid, 'gcm', 'aes', storage)
         } catch (e: any) {
-            console.error(
+            logger.error(
                 `[kd] The folder key for ${folderUid} can't be decrypted by the parent key ${parentUid} (${e.message})`
             )
         }
@@ -1294,7 +1294,7 @@ const processKdFolders = async (storage: VaultStorage, keeperDriveFolders?: Fold
                 inheritUserPermissions: toOptional(folder.inheritUserPermissions),
             })
         } catch (err: any) {
-            console.error(`[ks] folder ${folderUid} cannot be decrypted (${err.message})`)
+            logger.error(`[kd] folder ${folderUid} cannot be decrypted (${err.message})`)
         }
     }
 }
@@ -1429,7 +1429,7 @@ const processKdRecords = async (
                 isKeeperDriveData: true,
             })
         } catch (err: any) {
-            console.error(`[kd] record ${recordUid} cannot be decrypted: ${err.message}`)
+            logger.error(`[kd] record ${recordUid} cannot be decrypted: ${err.message}`)
         }
     }
 }

--- a/keeperapi/src/vault.ts
+++ b/keeperapi/src/vault.ts
@@ -1182,7 +1182,13 @@ const processKdFolderKeys = async (storage: VaultStorage, folderKeys?: Folder.IF
         if (!key.folderUid || !key.folderKey || !key.parentUid || isNil(key.encryptedBy)) continue
         const folderUid = webSafe64FromBytes(key.folderUid)
         const parentUid = webSafe64FromBytes(key.parentUid)
-        await platform.unwrapKey(key.folderKey, folderUid, parentUid, 'gcm', 'aes', storage)
+        try {
+            await platform.unwrapKey(key.folderKey, folderUid, parentUid, 'gcm', 'aes', storage)
+        } catch (e: any) {
+            console.error(
+                `[kd] The folder key for ${folderUid} can't be decrypted by the parent key ${parentUid} (${e.message})`
+            )
+        }
     }
 }
 


### PR DESCRIPTION
## Changes
1. Wrap the platform.unwrapKey with try-catch block in the processKdFolderKeys to avoid complete sync down failure